### PR TITLE
Add Heroku Template Gitignore

### DIFF
--- a/heroku/.gitignore
+++ b/heroku/.gitignore
@@ -1,0 +1,30 @@
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# Crash log files
+crash.log
+
+# REMOVE EVERYTHING THAT FOLLOWS THIS LINE IF YOU ARE NOT USING A REMOTE BACKEND
+# AND PLAN ON COMMITTING YOUR TERRAFORM CONFIGURATION AND STATE TO A GIT REPOSITORY.
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf


### PR DESCRIPTION
## What happened

Added a `.gitignore` file for the Heroku template specifically.

## Insight

When applying Terraform a couple of local-only files are created (to save the workspace you're currently working in for instance).

Also, in case we're using a remote backend (e.g. S3) we need to ignore a number of state files too.
 
## Proof Of Work

![image](https://user-images.githubusercontent.com/1441024/47841638-e04d9000-ddec-11e8-8934-fc386c451eae.png)
