### PR TITLE
Add missing type in RDS module

### DIFF
--- a/src/templates/aws/advanced.ts
+++ b/src/templates/aws/advanced.ts
@@ -260,7 +260,7 @@ export default class Advanced {
 
     variable "rds_autoscaling_max_capacity" {
       description = "Maximum number of RDS read replicas when autoscaling is enabled"
-      type =
+      type = number
     }\n\n`
     appendToFile('variables.tf', rdsVariablesContent, this.options)
 


### PR DESCRIPTION
N/A

## What happened 👀

The type of `rds_autoscaling_max_capacity` was missing.

## Insight 📝

N/A

## Proof Of Work 📹

The generated template should not have typo issues
