### PR TITLE
[#62] Lock the AWS provider version and Terraform version

### DIFF
--- a/skeleton/aws/main.tf
+++ b/skeleton/aws/main.tf
@@ -1,3 +1,16 @@
+terraform {
+  cloud {
+    organization = "organization"
+
+    workspaces {
+      name = "terraform_workspace"
+    }
+  }
+
+  # Terraform version
+  required_version = "~> 1.2.4"
+}
+
 # VPC
 
 # Security groups

--- a/skeleton/aws/main.tf
+++ b/skeleton/aws/main.tf
@@ -1,24 +1,3 @@
-terraform {
-  cloud {
-    organization = "organization"
-
-    workspaces {
-      name = "terraform_workspace"
-    }
-  }
-}
-
-provider "aws" {
-  region = var.region
-
-  default_tags {
-    tags = {
-      Environment = var.environment
-      Owner       = var.owner
-    }
-  }
-}
-
 # VPC
 
 # Security groups

--- a/skeleton/aws/providers.tf
+++ b/skeleton/aws/providers.tf
@@ -1,16 +1,4 @@
 terraform {
-  cloud {
-    organization = "organization"
-
-    workspaces {
-      name = "terraform_workspace"
-    }
-  }
-
-  # Terraform version
-  required_version = "~> 1.2.4"
-
-  # Provider versions
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/skeleton/aws/providers.tf
+++ b/skeleton/aws/providers.tf
@@ -1,0 +1,31 @@
+terraform {
+  cloud {
+    organization = "organization"
+
+    workspaces {
+      name = "terraform_workspace"
+    }
+  }
+
+  # Terraform version
+  required_version = "~> 1.2.4"
+
+  # Provider versions
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      Owner       = var.owner
+    }
+  }
+}

--- a/src/templates/aws/advanced.ts
+++ b/src/templates/aws/advanced.ts
@@ -37,6 +37,7 @@ export default class Advanced {
 
   private applyCommon(): void {
     copyFile('aws/main.tf', 'main.tf', this.options);
+    copyFile('aws/providers.tf', 'providers.tf', this.options);
     copyFile('aws/outputs.tf', 'outputs.tf', this.options);
     copyFile('aws/variables.tf', 'variables.tf', this.options);
   }


### PR DESCRIPTION
Resolves https://github.com/nimblehq/infrastructure-templates/issues/62

## What happened 👀

- Add versions for terraform and providers
- Move `terraform` and `provider` blocks into `providers.tf` file

## Insight 📝

N/A

## Proof Of Work 📹

N/A
