### PR TITLE
[#81] Update the Aurora Postgres engine version from 13 to 14 

### DIFF
--- a/skeleton/aws/modules/rds/variables.tf
+++ b/skeleton/aws/modules/rds/variables.tf
@@ -10,9 +10,9 @@ variable "engine" {
 }
 
 variable "engine_version" {
-  description = "The Aurora DB Engine version"
+  description = "The Aurora PostgreSQL DB Engine version"
   type        = string
-  default     = "13.6"
+  default     = "14.3"
 }
 
 variable "instance_type" {


### PR DESCRIPTION
- Close #81 

## What happened 👀

Update the default aurora DB engine to 14.3

## Insight 📝

Following the latest version from [this page](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.VersionPolicy.html#Aurora.VersionPolicy.MajorVersionLifetime).

![image](https://user-images.githubusercontent.com/77609814/181431178-93a08cab-8464-4ee1-8edc-c0153839b5e6.png)


## Proof Of Work 📹

Tested in the ewa payroll project: 
![image](https://user-images.githubusercontent.com/77609814/181440578-9e749881-2c85-4e30-b598-f133854ef85c.png)
