### PR TITLE
[#111] Update the load balancer to support sticky sessions

### DIFF
--- a/skeleton/aws/modules/alb/main.tf
+++ b/skeleton/aws/modules/alb/main.tf
@@ -36,8 +36,8 @@ resource "aws_lb_target_group" "target_group" {
     for_each = var.enable_stickiness ? [1] : []
 
     content {
-      enabled         = true
-      type            = var.stickiness_type
+      enabled = true
+      type    = var.stickiness_type
     }
   }
 }

--- a/skeleton/aws/modules/alb/main.tf
+++ b/skeleton/aws/modules/alb/main.tf
@@ -36,7 +36,7 @@ resource "aws_lb_target_group" "target_group" {
     for_each = var.enable_stickiness ? [1] : []
 
     content {
-      enabled = true
+      enabled = var.enable_stickiness
       type    = var.stickiness_type
     }
   }

--- a/skeleton/aws/modules/alb/main.tf
+++ b/skeleton/aws/modules/alb/main.tf
@@ -31,6 +31,15 @@ resource "aws_lb_target_group" "target_group" {
     port                = var.app_port
     unhealthy_threshold = 2
   }
+
+  dynamic "stickiness" {
+    for_each = var.enable_stickiness ? [1] : []
+
+    content {
+      enabled         = true
+      type            = var.stickiness_type
+    }
+  }
 }
 
 resource "aws_lb_listener" "app_http" {

--- a/skeleton/aws/modules/alb/variables.tf
+++ b/skeleton/aws/modules/alb/variables.tf
@@ -27,3 +27,15 @@ variable "app_port" {
   description = "Application running port"
   type        = number
 }
+
+variable "enable_stickiness" {
+  description = "Enable stickiness"
+  type        = bool
+  default     = false
+}
+
+variable "stickiness_type" {
+  description = "Stickiness type"
+  type        = string
+  default     = "lb_cookie"
+}

--- a/skeleton/aws/modules/bastion/variables.tf
+++ b/skeleton/aws/modules/bastion/variables.tf
@@ -5,35 +5,35 @@ variable "namespace" {
 
 variable "subnet_ids" {
   description = "The public setnet IsD for the instance"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "instance_security_group_ids" {
   description = "The security group IDs for the instance"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "image_id" {
   description = "The AMI image ID"
-  default = "ami-0801a1e12f4a9ccc0"
+  default     = "ami-0801a1e12f4a9ccc0"
 }
 
 variable "instance_type" {
   description = "The instance type"
-  default = "t3.nano"
+  default     = "t3.nano"
 }
 
 variable "instance_desired_count" {
   description = "The desired number of the instance"
-  default = 1
+  default     = 1
 }
 
 variable "max_instance_count" {
   description = "The maximum number of the instance"
-  default = 1
+  default     = 1
 }
 
 variable "min_instance_count" {
   description = "The minimum number of the instance"
-  default = 1
+  default     = 1
 }

--- a/skeleton/aws/modules/vpc/variables.tf
+++ b/skeleton/aws/modules/vpc/variables.tf
@@ -10,36 +10,36 @@ variable "cidr" {
 
 variable "private_subnet_cidrs" {
   description = "VPC private subnet CIDRs"
-  type    = list(any)
-  default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  type        = list(any)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
 variable "public_subnet_cidrs" {
   description = "VPC public subnet CIDRs"
-  type    = list(any)
-  default = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  type        = list(any)
+  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
 }
 
 variable "enable_nat_gateway" {
   description = "VPC NAT gateway flag"
-  type    = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "single_nat_gateway" {
   description = "VPC single NAT gateway flag"
-  type    = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "one_nat_gateway_per_az" {
   description = "VPC one NAT gateway per AZ flag"
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "enable_dns_hostnames" {
   description = "VPC DNS hostnames flag"
-  type    = bool
-  default = true
+  type        = bool
+  default     = true
 }

--- a/src/templates/aws/addons/alb.ts
+++ b/src/templates/aws/addons/alb.ts
@@ -13,6 +13,18 @@ const albVariablesContent = dedent`
       description = "Application domain"
       type        = string
     }
+
+    variable "enable_alb_stickiness" {
+      description = "Enable sticky sessions for ALB"
+      type        = bool
+      default     = false
+    }
+
+    variable "alb_stickiness_type" {
+      description = "ALB stickiness type"
+      type        = string
+      default     = "lb_cookie"
+    }
   \n`;
 const albModuleContent = dedent`
     module "alb" {
@@ -24,6 +36,8 @@ const albModuleContent = dedent`
       subnet_ids         = module.vpc.public_subnet_ids
       security_group_ids = module.security_group.alb_security_group_ids
       health_check_path  = var.health_check_path
+      enable_stickiness  = var.enable_alb_stickiness
+      stickiness_type    = var.alb_stickiness_type
     }
   \n`;
 const albOutputsContent = dedent`


### PR DESCRIPTION
- Close #111 

## What happened 👀

- Add `enable_alb_stickiness` and `alb_stickiness_type` for enabling ALB sticky sessions
- Run `terraform fmt` to indent code

## Insight 📝

N/A

## Proof Of Work 📹

N/A
