### PR TITLE
[#119] Use latest task definition from either AWS or terraform state

### DIFF
--- a/skeleton/aws/modules/bastion/variables.tf
+++ b/skeleton/aws/modules/bastion/variables.tf
@@ -5,35 +5,35 @@ variable "namespace" {
 
 variable "subnet_ids" {
   description = "The public setnet IsD for the instance"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "instance_security_group_ids" {
   description = "The security group IDs for the instance"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "image_id" {
   description = "The AMI image ID"
-  default = "ami-0801a1e12f4a9ccc0"
+  default     = "ami-0801a1e12f4a9ccc0"
 }
 
 variable "instance_type" {
   description = "The instance type"
-  default = "t3.nano"
+  default     = "t3.nano"
 }
 
 variable "instance_desired_count" {
   description = "The desired number of the instance"
-  default = 1
+  default     = 1
 }
 
 variable "max_instance_count" {
   description = "The maximum number of the instance"
-  default = 1
+  default     = 1
 }
 
 variable "min_instance_count" {
   description = "The minimum number of the instance"
-  default = 1
+  default     = 1
 }

--- a/skeleton/aws/modules/ecs/main.tf
+++ b/skeleton/aws/modules/ecs/main.tf
@@ -33,6 +33,11 @@ locals {
   }
 }
 
+# Current task definition on AWS including deployments outside terraform (e.g. CI deployments)
+data "aws_ecs_task_definition" "task" {
+  task_definition = aws_ecs_task_definition.main.family
+}
+
 data "aws_iam_policy_document" "ecs_task_execution_role" {
   version = "2012-10-17"
   statement {
@@ -87,7 +92,7 @@ resource "aws_ecs_service" "main" {
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
   desired_count                      = var.desired_count
-  task_definition                    = aws_ecs_task_definition.main.arn
+  task_definition                    = "${aws_ecs_task_definition.main.family}:${max("${aws_ecs_task_definition.main.revision}", "${data.aws_ecs_task_definition.task.revision}")}"
 
   deployment_circuit_breaker {
     enable   = true

--- a/skeleton/aws/modules/vpc/variables.tf
+++ b/skeleton/aws/modules/vpc/variables.tf
@@ -10,36 +10,36 @@ variable "cidr" {
 
 variable "private_subnet_cidrs" {
   description = "VPC private subnet CIDRs"
-  type    = list(any)
-  default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  type        = list(any)
+  default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
 }
 
 variable "public_subnet_cidrs" {
   description = "VPC public subnet CIDRs"
-  type    = list(any)
-  default = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  type        = list(any)
+  default     = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
 }
 
 variable "enable_nat_gateway" {
   description = "VPC NAT gateway flag"
-  type    = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "single_nat_gateway" {
   description = "VPC single NAT gateway flag"
-  type    = bool
-  default = true
+  type        = bool
+  default     = true
 }
 
 variable "one_nat_gateway_per_az" {
   description = "VPC one NAT gateway per AZ flag"
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
 }
 
 variable "enable_dns_hostnames" {
   description = "VPC DNS hostnames flag"
-  type    = bool
-  default = true
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
- Close #119

## What happened 👀

✅ Fetch the most recent task definition from AWS and choose the latest task definition version for deployment

## Insight 📝

Previously terraform would use the task definition version from its saved state. 
This did NOT account for incrementing task definitions on AWS from outside sources, (e.g CI deployments)

- Example usage of implementation from https://registry.terraform.io/providers/aaronfeng/aws/latest/docs/data-sources/ecs_task_definition#example-usage

## Proof Of Work 📹

Fix is used on Wo*** and applying the latest version from AWS or terraform state

![Screen Shot 2022-09-28 at 10 23 06 AM](https://user-images.githubusercontent.com/34730459/192680524-d47a38e4-2d94-447c-9580-f03f2ef50547.png)
