### PR TITLE
[#148] Fix: Wrong database_url string in SSM module

### DIFF
--- a/src/templates/aws/addons/ssm.ts
+++ b/src/templates/aws/addons/ssm.ts
@@ -9,6 +9,10 @@ const ssmVariablesContent = dedent`
     type = string
   }
 \n`;
+/* eslint-disable no-template-curly-in-string */
+const databaseUrlString =
+  'postgres://${var.rds_username}:${var.rds_password}@${module.rds.db_endpoint}/${var.rds_database_name}';
+/* eslint-enable no-template-curly-in-string */
 const ssmModuleContent = dedent`
   module "ssm" {
     source = "./modules/ssm"
@@ -16,7 +20,7 @@ const ssmModuleContent = dedent`
     namespace = var.namespace
 
     secrets = {
-      database_url = "postgres://\${var.rds_username}:\${var.rds_password}@\${module.rds.db_endpoint}/\${var.rds_database_name}"
+      database_url = "${databaseUrlString}"
       secret_key_base = var.secret_key_base
     }
   }


### PR DESCRIPTION
- Close #148

## What happened 👀

- Fix the wrong `database_url` in SSM module

## Insight 📝

As we're using the [Template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to declare the multiple-line string, then we need to escape the `${}` by using `/${}`, but when writing it to the file, the `/` was not removed. That is why it's incorrect.

## Proof Of Work 📹

The generated code is correct:

**Before:**
![main_tf_—_infrastructure-templates](https://user-images.githubusercontent.com/7344405/210047128-56553c70-ef77-430f-9698-62818d004602.png)

**After:**
![main_tf_—_infrastructure-templates](https://user-images.githubusercontent.com/7344405/210047768-08f88d63-519d-4bd0-9528-ff0b4ca8245a.png)

