### PR TITLE
[#176] Replace cancel-workflow-action with GH concurrency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,16 +2,15 @@ name: Lint
 
 on: push
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   lint:
     name: Run linters
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: push
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/skeleton/addons/versionControl/github/.github/workflows/lint.yml
+++ b/skeleton/addons/versionControl/github/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 jobs:
   linting:

--- a/skeleton/addons/versionControl/github/.github/workflows/lint.yml
+++ b/skeleton/addons/versionControl/github/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
 env:
   TERRAFORM_VERSION: "1.3.9"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   linting:
     name: Linting
@@ -15,11 +19,6 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout the repository
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
- Close #176

## What happened 👀

- The `cancel-workflow-action` has been removed from both the template workflow and the generated project workflow.
- The `concurrency` attribute has been used in workflows to guarantee that only one job runs for each workflow.

## Insight 📝

- A discussion on Slack raised the need to move away from using the `cancel-workflow-action`: https://nimble-co.slack.com/archives/CSQG2QXFX/p1679635544024489
- The official documentation for using workflows can be found here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
- Similar implementations can also be found on the Rails templates: https://github.com/nimblehq/rails-templates/pull/398 
- and Compas: https://github.com/nimblehq/compass/pull/1228 repositories.

## Proof Of Work 📹

CI should pass 🤞 

Previous PR was canceled: https://github.com/nimblehq/infrastructure-templates/actions/runs/4508899643

<img width="1077" alt="image" src="https://user-images.githubusercontent.com/475367/227456363-66ef18b5-cf40-4306-94ef-42ab2a5cb1c9.png">

