### PR TITLE
[#155] Add tfsec to the CI of the generated project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ oclif.manifest.json
 yarn.lock
 /coverage
 .DS_Store
+
+# IDE
+.vscode
+.idea
+*.iml

--- a/skeleton/addons/versionControl/github/.github/workflows/lint.yml
+++ b/skeleton/addons/versionControl/github/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   TERRAFORM_VERSION: "1.3.9"
+  TFSEC_VERSION: "v1.28.1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,3 +32,9 @@ jobs:
 
       - name: Run Terraform format
         run: terraform fmt -recursive -check
+
+      - name: Run tfsec linter
+        id: tfsec
+        uses: aquasecurity/tfsec-action@v1.0.3
+        with:
+          version: ${{ env.TFSEC_VERSION }}

--- a/skeleton/aws/modules/alb/main.tf
+++ b/skeleton/aws/modules/alb/main.tf
@@ -1,3 +1,4 @@
+# tfsec:ignore:aws-elb-alb-not-public
 resource "aws_lb" "main" {
   name               = "${var.namespace}-alb"
   internal           = false
@@ -6,6 +7,7 @@ resource "aws_lb" "main" {
   security_groups    = var.security_group_ids
 
   enable_deletion_protection = true
+  drop_invalid_header_fields = true
 
   access_logs {
     bucket  = "${var.namespace}-alb-log"
@@ -42,6 +44,7 @@ resource "aws_lb_target_group" "target_group" {
   }
 }
 
+# tfsec:ignore:aws-elb-http-not-used
 resource "aws_lb_listener" "app_http" {
   load_balancer_arn = aws_lb.main.arn
   port              = "80"

--- a/skeleton/aws/modules/bastion/main.tf
+++ b/skeleton/aws/modules/bastion/main.tf
@@ -1,3 +1,4 @@
+# tfsec:ignore:aws-ec2-no-public-ip
 resource "aws_launch_configuration" "bastion_instance" {
   name_prefix                 = "${var.namespace}-bastion-"
   image_id                    = var.image_id
@@ -8,6 +9,14 @@ resource "aws_launch_configuration" "bastion_instance" {
 
   lifecycle {
     create_before_destroy = true
+  }
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  root_block_device {
+    encrypted = true
   }
 }
 

--- a/skeleton/aws/modules/cloudwatch/main.tf
+++ b/skeleton/aws/modules/cloudwatch/main.tf
@@ -1,3 +1,4 @@
+# tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "main" {
   name              = "awslogs-${var.namespace}-log-group"
   retention_in_days = var.log_retention_in_days

--- a/skeleton/aws/modules/ecr/main.tf
+++ b/skeleton/aws/modules/ecr/main.tf
@@ -1,5 +1,10 @@
+# tfsec:ignore:aws-ecr-enforce-immutable-repository tfsec:ignore:aws-ecr-repository-customer-key
 resource "aws_ecr_repository" "main" {
   name = var.namespace
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
 }
 
 locals {

--- a/skeleton/aws/modules/ecs/main.tf
+++ b/skeleton/aws/modules/ecs/main.tf
@@ -84,6 +84,11 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_ssm_policy" {
 
 resource "aws_ecs_cluster" "main" {
   name = "${var.namespace}-ecs-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 resource "aws_ecs_task_definition" "main" {

--- a/skeleton/aws/modules/s3/main.tf
+++ b/skeleton/aws/modules/s3/main.tf
@@ -1,12 +1,22 @@
 data "aws_elb_service_account" "elb_service_account" {}
 
+# tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-encryption
 resource "aws_s3_bucket" "alb_log" {
-  bucket = "${var.namespace}-alb-log"
+  bucket        = "${var.namespace}-alb-log"
+  force_destroy = true
 }
 
 resource "aws_s3_bucket_acl" "alb_log_bucket_acl" {
   bucket = aws_s3_bucket.alb_log.id
   acl    = "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "alb_log" {
+  bucket                  = aws_s3_bucket.alb_log.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 locals {

--- a/skeleton/aws/modules/vpc/main.tf
+++ b/skeleton/aws/modules/vpc/main.tf
@@ -1,5 +1,6 @@
 data "aws_availability_zones" "available" {}
 
+# tfsec:ignore:aws-ec2-require-vpc-flow-logs-for-all-vpcs tfsec:ignore:aws-ec2-no-public-ip-subnet
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.0.0"

--- a/skeleton/core/.tool-versions
+++ b/skeleton/core/.tool-versions
@@ -1,1 +1,2 @@
 terraform 1.3.9
+tfsec 1.28.1

--- a/src/templates/aws/addons/alb.ts
+++ b/src/templates/aws/addons/alb.ts
@@ -64,6 +64,7 @@ const albSGMainContent = dedent`
     }
   }
 
+  # tfsec:ignore:aws-ec2-no-public-ingress-sgr
   resource "aws_security_group_rule" "alb_ingress_https" {
     type              = "ingress"
     security_group_id = aws_security_group.alb.id
@@ -71,8 +72,10 @@ const albSGMainContent = dedent`
     from_port         = 443
     to_port           = 443
     cidr_blocks       = ["0.0.0.0/0"]
+    description       = "From HTTPS to ALB"
   }
 
+  # tfsec:ignore:aws-ec2-no-public-ingress-sgr
   resource "aws_security_group_rule" "alb_ingress_http" {
     type              = "ingress"
     security_group_id = aws_security_group.alb.id
@@ -80,8 +83,10 @@ const albSGMainContent = dedent`
     from_port         = 80
     to_port           = 80
     cidr_blocks       = ["0.0.0.0/0"]
+    description       = "From HTTP to ALB"
   }
 
+  # tfsec:ignore:aws-ec2-no-public-egress-sgr
   resource "aws_security_group_rule" "alb_egress" {
     type              = "egress"
     security_group_id = aws_security_group.alb.id
@@ -89,6 +94,7 @@ const albSGMainContent = dedent`
     from_port         = var.app_port
     to_port           = var.app_port
     cidr_blocks       = ["0.0.0.0/0"]
+    description       = "From ALB to app"
   }`;
 
 const albSGOutputsContent = dedent`

--- a/src/templates/aws/addons/bastion.ts
+++ b/src/templates/aws/addons/bastion.ts
@@ -53,8 +53,9 @@ const bastionModuleContent = dedent`
 
 const bastionSGMainContent = dedent`
   resource "aws_security_group" "bastion" {
-    name   = "\${var.namespace}-bastion"
-    vpc_id = var.vpc_id
+    name        = "\${var.namespace}-bastion"
+    description = "Bastion Security Group"
+    vpc_id      = var.vpc_id
 
     tags = {
       Name = "\${var.namespace}-bastion-sg"
@@ -78,6 +79,7 @@ const bastionSGMainContent = dedent`
     to_port                  = 5432
     protocol                 = "tcp"
     source_security_group_id = aws_security_group.rds.id
+    description              = "From RDS to bastion"
   }`;
 
 const bastionSGOutputsContent = dedent`

--- a/src/templates/aws/addons/ecs.ts
+++ b/src/templates/aws/addons/ecs.ts
@@ -106,6 +106,7 @@ const ecsSGMainContent = dedent`
     from_port                = var.app_port
     to_port                  = var.app_port
     source_security_group_id = aws_security_group.alb.id
+    description              = "From internal VPC to app"
   }
 
   resource "aws_security_group_rule" "ecs_fargate_ingress_private" {
@@ -115,8 +116,10 @@ const ecsSGMainContent = dedent`
     from_port         = 0
     to_port           = 65535
     cidr_blocks       = var.private_subnets_cidr_blocks
+    description       = "From internal VPC to app"
   }
 
+  # tfsec:ignore:aws-ec2-no-public-egress-sgr
   resource "aws_security_group_rule" "ecs_fargate_egress_anywhere" {
     type              = "egress"
     security_group_id = aws_security_group.ecs_fargate.id
@@ -124,6 +127,7 @@ const ecsSGMainContent = dedent`
     from_port         = 0
     to_port           = 0
     cidr_blocks       = ["0.0.0.0/0"]
+    description       = "From app to everywhere"
   }`;
 
 const ecsSGOutputsContent = dedent`

--- a/src/templates/aws/addons/rds.ts
+++ b/src/templates/aws/addons/rds.ts
@@ -78,6 +78,7 @@ const rdsSGMainContent = dedent`
     to_port                  = 5432
     protocol                 = "tcp"
     source_security_group_id = aws_security_group.ecs_fargate.id
+    description              = "From app to DB"
   }
 
   resource "aws_security_group_rule" "rds_ingress_bastion" {
@@ -87,6 +88,7 @@ const rdsSGMainContent = dedent`
     to_port                  = 5432
     protocol                 = "tcp"
     source_security_group_id = aws_security_group.bastion.id
+    description              = "From bastion to RDS"
   }`;
 
 const rdsSGOutputsContent = dedent`


### PR DESCRIPTION
- Close #155

## What happened 👀

- Add the `tfsec` GH action into the generated project template. `TFSEC_VERSION` specified with the required `v` prefix, as `tfsec` uses this format for [release tags](https://github.com/aquasecurity/tfsec/tags).
- Also `tfsec` is included in the `.tool-versions` file for asdf, so that developers can run checks locally during the development process.

## Insight 📝

Our template had multiple warnings listed by tfsec. A few of these warnings were addressed and resolved accordingly, while others were silenced since they don't have much sense.

## Proof Of Work 📹

- [x] A new project was created and pushed to GitHub.
- [x] The `tfsec` action was initiated and the CI passed.

CI for newly generated project:

<img width="452" alt="image" src="https://user-images.githubusercontent.com/475367/233318344-f5550ce4-b501-4597-8cff-81c2e077bf01.png">