### PR TITLE
[#179] Fix: generated project can't be run

### DIFF
--- a/src/templates/aws/addons/alb.ts
+++ b/src/templates/aws/addons/alb.ts
@@ -33,7 +33,7 @@ const albVariablesContent = dedent`
   \n`;
 const albModuleContent = dedent`
     module "alb" {
-      source = "./modules/alb"
+      source = "../modules/alb"
 
       vpc_id             = module.vpc.vpc_id
       namespace          = var.namespace

--- a/src/templates/aws/addons/bastion.ts
+++ b/src/templates/aws/addons/bastion.ts
@@ -34,7 +34,7 @@ const bastionVariablesContent = dedent`
   }`;
 const bastionModuleContent = dedent`
   module "bastion" {
-    source = "./modules/bastion"
+    source = "../modules/bastion"
 
     subnet_ids                  = module.vpc.public_subnet_ids
     instance_security_group_ids = module.security_group.bastion_security_group_ids

--- a/src/templates/aws/addons/cloudwatch.ts
+++ b/src/templates/aws/addons/cloudwatch.ts
@@ -6,7 +6,7 @@ import { INFRA_BASE_MAIN_PATH } from '../../core/constants';
 
 const cloudwatchModuleContent = dedent`
   module "cloudwatch" {
-    source = "./modules/cloudwatch"
+    source = "../modules/cloudwatch"
 
     namespace = var.namespace
   }`;

--- a/src/templates/aws/addons/ecr.ts
+++ b/src/templates/aws/addons/ecr.ts
@@ -14,7 +14,7 @@ const ecrVariablesContent = dedent`
   }`;
 const ecrModuleContent = dedent`
   module "ecr" {
-    source = "./modules/ecr"
+    source = "../modules/ecr"
 
     namespace   = var.namespace
     image_limit = var.image_limit

--- a/src/templates/aws/addons/ecs.ts
+++ b/src/templates/aws/addons/ecs.ts
@@ -62,7 +62,7 @@ const ecsVariablesContent = dedent`
 
 const ecsModuleContent = dedent`
   module "ecs" {
-    source = "./modules/ecs"
+    source = "../modules/ecs"
 
     subnets                            = module.vpc.private_subnet_ids
     namespace                          = var.namespace

--- a/src/templates/aws/addons/rds.ts
+++ b/src/templates/aws/addons/rds.ts
@@ -39,7 +39,7 @@ const rdsVariablesContent = dedent`
   }`;
 const rdsModuleContent = dedent`
   module "rds" {
-    source = "./modules/rds"
+    source = "../modules/rds"
 
     namespace = var.namespace
 

--- a/src/templates/aws/addons/s3.ts
+++ b/src/templates/aws/addons/s3.ts
@@ -15,7 +15,7 @@ const s3OutputsContent = dedent`
 
 const s3ModuleContent = dedent`
   module "s3" {
-    source = "./modules/s3"
+    source = "../modules/s3"
 
     namespace   = var.namespace
   }`;

--- a/src/templates/aws/addons/securityGroup.ts
+++ b/src/templates/aws/addons/securityGroup.ts
@@ -13,7 +13,7 @@ const securityGroupVariablesContent = dedent`
   }`;
 const securityGroupModuleContent = dedent`
   module "security_group" {
-    source = "./modules/security_group"
+    source = "../modules/security_group"
 
     namespace                   = var.namespace
     vpc_id                      = module.vpc.vpc_id

--- a/src/templates/aws/addons/ssm.ts
+++ b/src/templates/aws/addons/ssm.ts
@@ -18,7 +18,7 @@ const databaseUrlString =
 /* eslint-enable no-template-curly-in-string */
 const ssmModuleContent = dedent`
   module "ssm" {
-    source = "./modules/ssm"
+    source = "../modules/ssm"
 
     namespace = var.namespace
 

--- a/src/templates/aws/addons/vpc.ts
+++ b/src/templates/aws/addons/vpc.ts
@@ -14,7 +14,7 @@ const vpcOutputsContent = dedent`
   }`;
 const vpcModuleContent = dedent`
   module "vpc" {
-    source    = "./modules/vpc"
+    source    = "../modules/vpc"
 
     namespace = var.namespace
   }`;


### PR DESCRIPTION
- Close #179

## What happened 👀

If we generate a project on the current `develop` branch, the generated projects cannot be initialized because of wrong paths to the modules. 

It happens because we changed the project structure in previous PRs.

## Proof Of Work 📹

The newly generated project now contains the correct paths to the modules.

Shared folder:

> Initializing modules...
> - ecr in ../modules/ecr

Base folder:

> Initializing modules...
> - alb in ../modules/alb
> - bastion in ../modules/bastion
> - cloudwatch in ../modules/cloudwatch
> - ecs in ../modules/ecs
> - rds in ../modules/rds
> Downloading registry.terraform.io/terraform-aws-modules/rds-aurora/aws 6.2.0 for rds.db...
> - rds.db in .terraform/modules/rds.db
> - s3 in ../modules/s3
> - security_group in ../modules/security_group
> - ssm in ../modules/ssm
> - vpc in ../modules/vpc
> Downloading registry.terraform.io/terraform-aws-modules/vpc/aws 3.0.0 for vpc.vpc...
> - vpc.vpc in .terraform/modules/vpc.vpc
