### PR TITLE
[#191] Add prompt to enable Terraform Cloud

### DIFF
--- a/.github/wiki/Getting-Started.md
+++ b/.github/wiki/Getting-Started.md
@@ -24,10 +24,6 @@ nimble-infra generate {project-name}
 nimble-infra install {addon-name} --project {project-name}
 ```
 
-> **Note**!\
-> Terraform Cloud is supported by default. You need to set the `organization` and `workspace` in the `terraform` block of the `main.tf` file to use it.
-> If you don't want to use Terraform Cloud, you can remove the `cloud` block in the `main.tf` file.
-
 ### Reference as a template
 
 > **Note**!\

--- a/package-lock.json
+++ b/package-lock.json
@@ -3665,9 +3665,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
-      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
       "engines": {
         "node": ">=6"
       },
@@ -14443,9 +14443,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
-      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g=="
     },
     "cli-table": {
       "version": "0.3.11",

--- a/src/commands/generate/index.test.ts
+++ b/src/commands/generate/index.test.ts
@@ -16,23 +16,23 @@ describe('Generator command', () => {
         const stdoutSpy = jest.spyOn(process.stdout, 'write');
 
         beforeAll(async () => {
-          (prompt as unknown as jest.Mock)
-            .mockResolvedValueOnce({
-              provider: 'aws',
-              versionControl: 'github',
-            })
-            .mockResolvedValueOnce({ infrastructureType: 'blank' });
+          (prompt as unknown as jest.Mock).mockResolvedValue({
+            provider: 'aws',
+            infrastructureType: 'blank',
+            versionControlEnabled: false,
+            terraformCloudEnabled: false,
+          });
 
           await Generator.run([projectDir]);
         });
 
         afterAll(() => {
-          jest.resetAllMocks();
+          jest.clearAllMocks();
           remove('/', projectDir);
         });
 
         it('creates expected directories', () => {
-          const expectedDirectories = ['.github/', 'core/', 'shared/'];
+          const expectedDirectories = ['core/', 'shared/'];
 
           expect(projectDir).toHaveDirectories(expectedDirectories);
         });
@@ -70,18 +70,18 @@ describe('Generator command', () => {
         const stdoutSpy = jest.spyOn(process.stdout, 'write');
 
         beforeAll(async () => {
-          (prompt as unknown as jest.Mock)
-            .mockResolvedValueOnce({
-              provider: 'aws',
-              versionControl: 'github',
-            })
-            .mockResolvedValueOnce({ infrastructureType: 'advanced' });
+          (prompt as unknown as jest.Mock).mockResolvedValue({
+            provider: 'aws',
+            infrastructureType: 'advanced',
+            versionControlEnabled: false,
+            terraformCloudEnabled: false,
+          });
 
           await Generator.run([projectDir]);
         });
 
         afterAll(() => {
-          jest.resetAllMocks();
+          jest.clearAllMocks();
           remove('/', projectDir);
         });
 
@@ -97,7 +97,6 @@ describe('Generator command', () => {
             'modules/security_group/',
             'modules/ssm/',
             'modules/vpc/',
-            '.github/',
           ];
 
           expect(projectDir).toHaveDirectories(expectedDirectories);
@@ -133,6 +132,8 @@ describe('Generator command', () => {
       beforeAll(async () => {
         (prompt as unknown as jest.Mock).mockResolvedValueOnce({
           provider: 'other',
+          versionControlEnabled: false,
+          terraformCloudEnabled: false,
         });
       });
 

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -2,6 +2,7 @@ import { Args, Command, ux } from '@oclif/core';
 import { prompt } from 'inquirer';
 
 import { generateAwsTemplate } from '@/generators/addons/aws';
+import { applyTerraformCloud } from '@/generators/addons/terraformCloud';
 import {
   applyVersionControl,
   versionControlChoices,
@@ -91,6 +92,7 @@ export default class Generator extends Command {
 
   private async applyGeneralParts(generalOptions: GeneralOptions) {
     await applyTerraformCore(generalOptions);
+    await applyTerraformCloud(generalOptions);
     await applyVersionControl(generalOptions);
   }
 }

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -3,17 +3,13 @@ import { prompt } from 'inquirer';
 
 import { generateAwsTemplate } from '@/generators/addons/aws';
 import { applyTerraformCloud } from '@/generators/addons/terraformCloud';
-import {
-  applyVersionControl,
-  versionControlChoices,
-} from '@/generators/addons/versionControl';
+import { applyVersionControl } from '@/generators/addons/versionControl';
 import { applyTerraformCore } from '@/generators/terraform';
 import { remove } from '@/helpers/file';
 import { postProcess } from '@/hooks/postProcess';
 
 type GeneralOptions = {
   projectName: string;
-  versionControl?: 'github' | 'none';
   provider: 'aws' | 'other' | string;
 };
 
@@ -49,15 +45,11 @@ export default class Generator extends Command {
   async run(): Promise<void> {
     const { args } = await this.parse(Generator);
 
-    const generalPrompt = await prompt<GeneralOptions>([
-      ...versionControlChoices,
-      ...providerChoices,
-    ]);
+    const generalPrompt = await prompt<GeneralOptions>([...providerChoices]);
 
     const generalOptions: GeneralOptions = {
       projectName: args.projectName,
       provider: generalPrompt.provider,
-      versionControl: generalPrompt.versionControl,
     };
 
     await this.generate(generalOptions);

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -17,7 +17,7 @@ const providerChoices = [
   {
     type: 'list',
     name: 'provider',
-    message: 'Which cloud provider would you like to use?',
+    message: 'Which cloud provider would you like to use? [AWS]',
     choices: [
       {
         value: 'aws',

--- a/src/commands/install/index.test.ts
+++ b/src/commands/install/index.test.ts
@@ -18,12 +18,12 @@ describe('Install add-on command', () => {
       const stdoutSpy = jest.spyOn(process.stdout, 'write');
 
       beforeAll(async () => {
-        (prompt as unknown as jest.Mock)
-          .mockResolvedValueOnce({
-            provider: provider,
-            versionControl: 'github',
-          })
-          .mockResolvedValueOnce({ infrastructureType: 'blank' });
+        (prompt as unknown as jest.Mock).mockResolvedValue({
+          provider: provider,
+          infrastructureType: 'blank',
+          versionControlEnabled: false,
+          terraformCloudEnabled: false,
+        });
 
         await Generator.run([projectDir]);
         await InstallAddon.run([
@@ -39,13 +39,7 @@ describe('Install add-on command', () => {
       });
 
       it('creates expected directories', () => {
-        const expectedDirectories = [
-          '.github/',
-          'core/',
-          'shared/',
-          'modules/',
-        ];
-
+        const expectedDirectories = ['core/', 'shared/', 'modules/'];
         expect(projectDir).toHaveDirectories(expectedDirectories);
       });
 
@@ -86,12 +80,12 @@ describe('Install add-on command', () => {
       const stdoutSpy = jest.spyOn(process.stdout, 'write');
 
       beforeAll(async () => {
-        (prompt as unknown as jest.Mock)
-          .mockResolvedValueOnce({
-            provider: provider,
-            versionControl: 'github',
-          })
-          .mockResolvedValueOnce({ infrastructureType: 'blank' });
+        (prompt as unknown as jest.Mock).mockResolvedValue({
+          provider: provider,
+          infrastructureType: 'blank',
+          versionControlEnabled: false,
+          terraformCloudEnabled: false,
+        });
 
         await Generator.run([projectDir]);
         await InstallAddon.run([

--- a/src/generators/addons/terraformCloud/index.test.ts
+++ b/src/generators/addons/terraformCloud/index.test.ts
@@ -21,7 +21,7 @@ describe('Terrafom Cloud add-on', () => {
       (prompt as unknown as jest.Mock).mockResolvedValue({
         terraformCloudEnabled: true,
         terraformCloudOrganization: 'YOUR_ORGANIZATION',
-        terraformCloudBaseWorkspace: 'YOUR_BASE_WORKSPACE',
+        terraformCloudCoreWorkspace: 'YOUR_CORE_WORKSPACE',
         terraformCloudSharedWorkspace: 'YOUR_SHARED_WORKSPACE',
       });
 
@@ -34,19 +34,19 @@ describe('Terrafom Cloud add-on', () => {
     });
 
     it('creates expected files', () => {
-      const expectedFiles = ['base/main.tf', 'shared/main.tf'];
+      const expectedFiles = ['core/main.tf', 'shared/main.tf'];
 
       expect(projectDir).toHaveFiles(expectedFiles);
     });
 
     it('adds the cloud block to main.tf files', () => {
       expect(projectDir).toHaveContentInFile(
-        'base/main.tf',
+        'core/main.tf',
         `
           cloud {
             organization = "YOUR_ORGANIZATION"
             workspaces {
-              name = "YOUR_BASE_WORKSPACE"
+              name = "YOUR_CORE_WORKSPACE"
             }
           }
         `,
@@ -91,7 +91,7 @@ describe('Terrafom Cloud add-on', () => {
     });
 
     it('creates expected files', () => {
-      const expectedFiles = ['base/main.tf', 'shared/main.tf'];
+      const expectedFiles = ['core/main.tf', 'shared/main.tf'];
 
       expect(projectDir).toHaveFiles(expectedFiles);
     });
@@ -100,7 +100,7 @@ describe('Terrafom Cloud add-on', () => {
       const expectedContent = 'cloud {';
 
       expect(projectDir).not.toHaveContentInFile(
-        'base/main.tf',
+        'core/main.tf',
         expectedContent
       );
       expect(projectDir).not.toHaveContentInFile(

--- a/src/generators/addons/terraformCloud/index.test.ts
+++ b/src/generators/addons/terraformCloud/index.test.ts
@@ -21,7 +21,8 @@ describe('Terrafom Cloud add-on', () => {
       (prompt as unknown as jest.Mock).mockResolvedValue({
         terraformCloudEnabled: true,
         terraformCloudOrganization: 'YOUR_ORGANIZATION',
-        terraformCloudWorkspace: 'YOUR_WORKSPACE',
+        terraformCloudBaseWorkspace: 'YOUR_BASE_WORKSPACE',
+        terraformCloudSharedWorkspace: 'YOUR_SHARED_WORKSPACE',
       });
 
       applyTerraformCore(generalOptions);
@@ -39,21 +40,30 @@ describe('Terrafom Cloud add-on', () => {
     });
 
     it('adds the cloud block to main.tf files', () => {
-      const expectedContent = `
-        cloud {
-          organization = "YOUR_ORGANIZATION"
-          workspaces {
-            name = "YOUR_WORKSPACE"
+      expect(projectDir).toHaveContentInFile(
+        'base/main.tf',
+        `
+          cloud {
+            organization = "YOUR_ORGANIZATION"
+            workspaces {
+              name = "YOUR_BASE_WORKSPACE"
+            }
           }
+        `,
+        {
+          ignoreSpaces: true,
         }
-      `;
-
-      expect(projectDir).toHaveContentInFile('base/main.tf', expectedContent, {
-        ignoreSpaces: true,
-      });
+      );
       expect(projectDir).toHaveContentInFile(
         'shared/main.tf',
-        expectedContent,
+        `
+          cloud {
+            organization = "YOUR_ORGANIZATION"
+            workspaces {
+              name = "YOUR_SHARED_WORKSPACE"
+            }
+          }
+        `,
         { ignoreSpaces: true }
       );
     });

--- a/src/generators/addons/terraformCloud/index.test.ts
+++ b/src/generators/addons/terraformCloud/index.test.ts
@@ -1,0 +1,102 @@
+import { prompt } from 'inquirer';
+
+import { GeneralOptions } from '@/commands/generate';
+import { applyTerraformCore } from '@/generators/terraform';
+import { remove } from '@/helpers/file';
+
+import { applyTerraformCloud } from '.';
+
+jest.mock('inquirer');
+
+describe('Terrafom Cloud add-on', () => {
+  describe('given terraformCloudEnabled is true', () => {
+    const projectDir = 'terraform-cloud-addon-test';
+
+    beforeAll(() => {
+      const generalOptions: GeneralOptions = {
+        projectName: projectDir,
+        provider: 'aws',
+      };
+
+      (prompt as unknown as jest.Mock).mockResolvedValue({
+        terraformCloudEnabled: true,
+        terraformCloudOrganization: 'YOUR_ORGANIZATION',
+        terraformCloudWorkspace: 'YOUR_WORKSPACE',
+      });
+
+      applyTerraformCore(generalOptions);
+      applyTerraformCloud(generalOptions);
+    });
+
+    afterAll(() => {
+      remove('/', projectDir);
+    });
+
+    it('creates expected files', () => {
+      const expectedFiles = ['base/main.tf', 'shared/main.tf'];
+
+      expect(projectDir).toHaveFiles(expectedFiles);
+    });
+
+    it('adds the cloud block to main.tf files', () => {
+      const expectedContent = `
+        cloud {
+          organization = "YOUR_ORGANIZATION"
+          workspaces {
+            name = "YOUR_WORKSPACE"
+          }
+        }
+      `;
+
+      expect(projectDir).toHaveContentInFile('base/main.tf', expectedContent, {
+        ignoreSpaces: true,
+      });
+      expect(projectDir).toHaveContentInFile(
+        'shared/main.tf',
+        expectedContent,
+        { ignoreSpaces: true }
+      );
+    });
+  });
+
+  describe('given terraformCloudEnabled is false', () => {
+    const projectDir = 'terraform-cloud-none-addon-test';
+
+    beforeAll(() => {
+      const generalOptions: GeneralOptions = {
+        projectName: projectDir,
+        provider: 'aws',
+      };
+
+      (prompt as unknown as jest.Mock).mockResolvedValueOnce({
+        terraformCloudEnabled: false,
+      });
+
+      applyTerraformCore(generalOptions);
+      applyTerraformCloud(generalOptions);
+    });
+
+    afterAll(() => {
+      remove('/', projectDir);
+    });
+
+    it('creates expected files', () => {
+      const expectedFiles = ['base/main.tf', 'shared/main.tf'];
+
+      expect(projectDir).toHaveFiles(expectedFiles);
+    });
+
+    it('does NOT add the cloud block to main.tf files', () => {
+      const expectedContent = 'cloud {';
+
+      expect(projectDir).not.toHaveContentInFile(
+        'base/main.tf',
+        expectedContent
+      );
+      expect(projectDir).not.toHaveContentInFile(
+        'shared/main.tf',
+        expectedContent
+      );
+    });
+  });
+});

--- a/src/generators/addons/terraformCloud/index.ts
+++ b/src/generators/addons/terraformCloud/index.ts
@@ -33,20 +33,22 @@ const getTerraformCloudOptions = async (
       {
         type: 'input',
         name: 'terraformCloudOrganization',
-        message: 'What is your Terraform Cloud organization?',
+        message: 'What is your Terraform Cloud organization name?',
         default: 'nimble',
       },
       {
         type: 'input',
         name: 'terraformCloudCoreWorkspace',
-        message: 'What is your Terraform Cloud for the `core` workspace?',
-        default: projectName,
+        message:
+          'What is your Terraform Cloud workspace name for the `core` workspace?',
+        default: `${projectName}`,
       },
       {
         type: 'input',
         name: 'terraformCloudSharedWorkspace',
-        message: 'What is your Terraform Cloud for the `shared` workspace?',
-        default: projectName,
+        message:
+          'What is your Terraform Cloud workspace name for the `shared` workspace?',
+        default: `${projectName}-shared`,
       },
     ]);
 

--- a/src/generators/addons/terraformCloud/index.ts
+++ b/src/generators/addons/terraformCloud/index.ts
@@ -1,0 +1,84 @@
+import dedent = require('dedent');
+import { prompt } from 'inquirer';
+
+import { GeneralOptions } from '@/commands/generate';
+import {
+  INFRA_CORE_MAIN_PATH,
+  INFRA_SHARED_MAIN_PATH,
+} from '@/generators/terraform/constants';
+import { injectToFile } from '@/helpers/file';
+
+type TerraformCloudOptions = {
+  enabled: boolean;
+  organization: string;
+  workspace: string;
+};
+
+const getTerraformCloudOptions = async (): Promise<TerraformCloudOptions> => {
+  const terraformCloudPrompt = await prompt([
+    {
+      type: 'confirm',
+      name: 'enabled',
+      message: 'Would you like to enable Terraform Cloud?',
+      default: true,
+    },
+  ]);
+
+  if (terraformCloudPrompt.enabled) {
+    const terraformCloudOptions = await prompt([
+      {
+        type: 'input',
+        name: 'organization',
+        message: 'What is your Terraform Cloud organization?',
+      },
+      {
+        type: 'input',
+        name: 'workspace',
+        message: 'What is your Terraform Cloud workspace?',
+      },
+    ]);
+
+    return {
+      enabled: true,
+      ...terraformCloudOptions,
+    };
+  }
+
+  return {
+    enabled: false,
+    organization: '',
+    workspace: '',
+  };
+};
+
+const terraformCloudMainContent = (
+  terraformCloudOptions: TerraformCloudOptions
+) => dedent`
+  cloud {
+    organization = "${terraformCloudOptions.organization}"
+    workspaces {
+      name = "${terraformCloudOptions.workspace}"
+    }
+  }
+`;
+
+const applyTerraformCloud = async ({
+  projectName,
+}: GeneralOptions): Promise<void> => {
+  const terraformCloudOptions = await getTerraformCloudOptions();
+
+  if (terraformCloudOptions.enabled) {
+    [INFRA_CORE_MAIN_PATH, INFRA_SHARED_MAIN_PATH].forEach((path) => {
+      injectToFile(
+        path,
+        terraformCloudMainContent(terraformCloudOptions),
+        projectName,
+        {
+          insertAfter: 'terraform {',
+        }
+      );
+    });
+  }
+};
+
+export { applyTerraformCloud };

--- a/src/generators/addons/terraformCloud/index.ts
+++ b/src/generators/addons/terraformCloud/index.ts
@@ -10,8 +10,8 @@ import { injectToFile } from '@/helpers/file';
 
 type TerraformCloudOptions = {
   terraformCloudEnabled: boolean;
-  organization: string;
-  workspace: string;
+  terraformCloudOrganization: string;
+  terraformCloudWorkspace: string;
 };
 
 const getTerraformCloudOptions = async (): Promise<TerraformCloudOptions> => {
@@ -28,12 +28,12 @@ const getTerraformCloudOptions = async (): Promise<TerraformCloudOptions> => {
     const terraformCloudOptions = await prompt([
       {
         type: 'input',
-        name: 'organization',
+        name: 'terraformCloudOrganization',
         message: 'What is your Terraform Cloud organization?',
       },
       {
         type: 'input',
-        name: 'workspace',
+        name: 'terraformCloudWorkspace',
         message: 'What is your Terraform Cloud workspace?',
       },
     ]);
@@ -46,8 +46,8 @@ const getTerraformCloudOptions = async (): Promise<TerraformCloudOptions> => {
 
   return {
     terraformCloudEnabled: false,
-    organization: '',
-    workspace: '',
+    terraformCloudOrganization: '',
+    terraformCloudWorkspace: '',
   };
 };
 
@@ -55,9 +55,9 @@ const terraformCloudMainContent = (
   terraformCloudOptions: TerraformCloudOptions
 ) => dedent`
   cloud {
-    organization = "${terraformCloudOptions.organization}"
+    organization = "${terraformCloudOptions.terraformCloudOrganization}"
     workspaces {
-      name = "${terraformCloudOptions.workspace}"
+      name = "${terraformCloudOptions.terraformCloudWorkspace}"
     }
   }
 `;

--- a/src/generators/addons/terraformCloud/index.ts
+++ b/src/generators/addons/terraformCloud/index.ts
@@ -14,7 +14,9 @@ type TerraformCloudOptions = {
   terraformCloudWorkspace: string;
 };
 
-const getTerraformCloudOptions = async (): Promise<TerraformCloudOptions> => {
+const getTerraformCloudOptions = async (
+  projectName: string
+): Promise<TerraformCloudOptions> => {
   const terraformCloudPrompt = await prompt([
     {
       type: 'confirm',
@@ -30,11 +32,13 @@ const getTerraformCloudOptions = async (): Promise<TerraformCloudOptions> => {
         type: 'input',
         name: 'terraformCloudOrganization',
         message: 'What is your Terraform Cloud organization?',
+        default: 'nimble',
       },
       {
         type: 'input',
         name: 'terraformCloudWorkspace',
         message: 'What is your Terraform Cloud workspace?',
+        default: projectName,
       },
     ]);
 
@@ -65,7 +69,7 @@ const terraformCloudMainContent = (
 const applyTerraformCloud = async ({
   projectName,
 }: GeneralOptions): Promise<void> => {
-  const terraformCloudOptions = await getTerraformCloudOptions();
+  const terraformCloudOptions = await getTerraformCloudOptions(projectName);
 
   if (terraformCloudOptions.terraformCloudEnabled) {
     [INFRA_CORE_MAIN_PATH, INFRA_SHARED_MAIN_PATH].forEach((path) => {

--- a/src/generators/addons/terraformCloud/index.ts
+++ b/src/generators/addons/terraformCloud/index.ts
@@ -9,7 +9,7 @@ import {
 import { injectToFile } from '@/helpers/file';
 
 type TerraformCloudOptions = {
-  enabled: boolean;
+  terraformCloudEnabled: boolean;
   organization: string;
   workspace: string;
 };
@@ -18,13 +18,13 @@ const getTerraformCloudOptions = async (): Promise<TerraformCloudOptions> => {
   const terraformCloudPrompt = await prompt([
     {
       type: 'confirm',
-      name: 'enabled',
+      name: 'terraformCloudEnabled',
       message: 'Would you like to enable Terraform Cloud?',
       default: false,
     },
   ]);
 
-  if (terraformCloudPrompt.enabled) {
+  if (terraformCloudPrompt.terraformCloudEnabled) {
     const terraformCloudOptions = await prompt([
       {
         type: 'input',
@@ -39,13 +39,13 @@ const getTerraformCloudOptions = async (): Promise<TerraformCloudOptions> => {
     ]);
 
     return {
-      enabled: true,
+      terraformCloudEnabled: true,
       ...terraformCloudOptions,
     };
   }
 
   return {
-    enabled: false,
+    terraformCloudEnabled: false,
     organization: '',
     workspace: '',
   };
@@ -67,7 +67,7 @@ const applyTerraformCloud = async ({
 }: GeneralOptions): Promise<void> => {
   const terraformCloudOptions = await getTerraformCloudOptions();
 
-  if (terraformCloudOptions.enabled) {
+  if (terraformCloudOptions.terraformCloudEnabled) {
     [INFRA_CORE_MAIN_PATH, INFRA_SHARED_MAIN_PATH].forEach((path) => {
       injectToFile(
         path,

--- a/src/generators/addons/terraformCloud/index.ts
+++ b/src/generators/addons/terraformCloud/index.ts
@@ -20,7 +20,7 @@ const getTerraformCloudOptions = async (): Promise<TerraformCloudOptions> => {
       type: 'confirm',
       name: 'enabled',
       message: 'Would you like to enable Terraform Cloud?',
-      default: true,
+      default: false,
     },
   ]);
 

--- a/src/generators/addons/versionControl/index.test.ts
+++ b/src/generators/addons/versionControl/index.test.ts
@@ -1,25 +1,32 @@
+import { prompt } from 'inquirer';
+
 import { GeneralOptions } from '@/commands/generate';
 import { remove } from '@/helpers/file';
 
 import { applyVersionControl } from '.';
 
+jest.mock('inquirer');
+
 describe('Version control add-on', () => {
-  describe('given valid GeneralOptions', () => {
-    describe('given github version control', () => {
+  describe('given versionControlEnabled is true', () => {
+    describe('given github service', () => {
       const projectDir = 'version-control-github-addon-test';
 
       beforeAll(() => {
         const generalOptions: GeneralOptions = {
           projectName: projectDir,
           provider: 'aws',
-          versionControl: 'github',
         };
+
+        (prompt as unknown as jest.Mock).mockResolvedValue({
+          versionControlEnabled: true,
+          versionControlService: 'github',
+        });
 
         applyVersionControl(generalOptions);
       });
 
       afterAll(() => {
-        jest.clearAllMocks();
         remove('/', projectDir);
       });
 
@@ -38,21 +45,23 @@ describe('Version control add-on', () => {
       });
     });
 
-    describe('given none version control', () => {
+    describe('given versionControlEnabled is false', () => {
       const projectDir = 'version-control-none-addon-test';
 
       beforeAll(() => {
         const generalOptions: GeneralOptions = {
           projectName: projectDir,
           provider: 'aws',
-          versionControl: 'none',
         };
+
+        (prompt as unknown as jest.Mock).mockResolvedValueOnce({
+          versionControlEnabled: false,
+        });
 
         applyVersionControl(generalOptions);
       });
 
       afterAll(() => {
-        jest.clearAllMocks();
         remove('/', projectDir);
       });
 

--- a/src/generators/addons/versionControl/index.test.ts
+++ b/src/generators/addons/versionControl/index.test.ts
@@ -9,7 +9,7 @@ jest.mock('inquirer');
 
 describe('Version control add-on', () => {
   describe('given versionControlEnabled is true', () => {
-    describe('given github service', () => {
+    describe('given GitHub service', () => {
       const projectDir = 'version-control-github-addon-test';
 
       beforeAll(() => {

--- a/src/generators/addons/versionControl/index.ts
+++ b/src/generators/addons/versionControl/index.ts
@@ -13,7 +13,7 @@ const getVersionControlOptions = async (): Promise<VersionControlOptions> => {
     {
       type: 'confirm',
       name: 'versionControlEnabled',
-      message: 'Would you like to enable git version control?',
+      message: 'Would you like to enable git version control? [GitHub]',
       default: false,
     },
   ]);

--- a/src/generators/addons/versionControl/index.ts
+++ b/src/generators/addons/versionControl/index.ts
@@ -4,7 +4,7 @@ import { GeneralOptions } from '@/commands/generate';
 import { copy } from '@/helpers/file';
 
 type VersionControlOptions = {
-  enabled: boolean;
+  versionControlEnabled: boolean;
   versionControlService: string;
 };
 
@@ -12,13 +12,13 @@ const getVersionControlOptions = async (): Promise<VersionControlOptions> => {
   const versionControlPrompt = await prompt([
     {
       type: 'confirm',
-      name: 'enabled',
+      name: 'versionControlEnabled',
       message: 'Would you like to enable version control?',
       default: false,
     },
   ]);
 
-  if (versionControlPrompt.enabled) {
+  if (versionControlPrompt.versionControlEnabled) {
     const versionControlOptions = await prompt([
       {
         type: 'list',
@@ -39,13 +39,13 @@ const getVersionControlOptions = async (): Promise<VersionControlOptions> => {
     ]);
 
     return {
-      enabled: true,
+      versionControlEnabled: true,
       ...versionControlOptions,
     };
   }
 
   return {
-    enabled: false,
+    versionControlEnabled: false,
     versionControlService: '',
   };
 };
@@ -53,7 +53,7 @@ const getVersionControlOptions = async (): Promise<VersionControlOptions> => {
 const applyVersionControl = async ({ projectName }: GeneralOptions) => {
   const versionControlOptions = await getVersionControlOptions();
 
-  if (versionControlOptions.enabled) {
+  if (versionControlOptions.versionControlEnabled) {
     if (versionControlOptions.versionControlService === 'github') {
       copy('addons/versionControl/github', '.', projectName);
     }

--- a/src/generators/addons/versionControl/index.ts
+++ b/src/generators/addons/versionControl/index.ts
@@ -1,30 +1,63 @@
+import { prompt } from 'inquirer';
+
 import { GeneralOptions } from '@/commands/generate';
 import { copy } from '@/helpers/file';
 
-const versionControlChoices = [
-  {
-    type: 'list',
-    name: 'versionControl',
-    message: 'Which version control hosting would you like to use?',
-    choices: [
-      {
-        value: 'github',
-        name: 'GitHub',
-      },
-      {
-        value: 'none',
-        name: 'None',
-      },
-    ],
-  },
-];
+type VersionControlOptions = {
+  enabled: boolean;
+  versionControlService: string;
+};
 
-const applyVersionControl = async (generalOptions: GeneralOptions) => {
-  const { versionControl, projectName } = generalOptions;
+const getVersionControlOptions = async (): Promise<VersionControlOptions> => {
+  const versionControlPrompt = await prompt([
+    {
+      type: 'confirm',
+      name: 'enabled',
+      message: 'Would you like to enable version control?',
+      default: false,
+    },
+  ]);
 
-  if (versionControl === 'github') {
-    copy('addons/versionControl/github', '.', projectName);
+  if (versionControlPrompt.enabled) {
+    const versionControlOptions = await prompt([
+      {
+        type: 'list',
+        name: 'versionControlService',
+        message: 'Which version control hosting would you like to use?',
+        choices: [
+          {
+            name: 'GitHub',
+            value: 'github',
+          },
+          {
+            name: 'GitLab',
+            value: 'gitlab',
+            disabled: '(Coming soon)',
+          },
+        ],
+      },
+    ]);
+
+    return {
+      enabled: true,
+      ...versionControlOptions,
+    };
+  }
+
+  return {
+    enabled: false,
+    versionControlService: '',
+  };
+};
+
+const applyVersionControl = async ({ projectName }: GeneralOptions) => {
+  const versionControlOptions = await getVersionControlOptions();
+
+  if (versionControlOptions.enabled) {
+    if (versionControlOptions.versionControlService === 'github') {
+      copy('addons/versionControl/github', '.', projectName);
+    }
   }
 };
 
-export { versionControlChoices, applyVersionControl };
+export { applyVersionControl };

--- a/src/generators/addons/versionControl/index.ts
+++ b/src/generators/addons/versionControl/index.ts
@@ -13,7 +13,7 @@ const getVersionControlOptions = async (): Promise<VersionControlOptions> => {
     {
       type: 'confirm',
       name: 'versionControlEnabled',
-      message: 'Would you like to enable version control?',
+      message: 'Would you like to enable git version control?',
       default: false,
     },
   ]);
@@ -23,7 +23,7 @@ const getVersionControlOptions = async (): Promise<VersionControlOptions> => {
       {
         type: 'list',
         name: 'versionControlService',
-        message: 'Which version control hosting would you like to use?',
+        message: 'Which git version control hosting would you like to use?',
         choices: [
           {
             name: 'GitHub',
@@ -32,7 +32,7 @@ const getVersionControlOptions = async (): Promise<VersionControlOptions> => {
           {
             name: 'GitLab',
             value: 'gitlab',
-            disabled: '(Coming soon)',
+            disabled: 'Coming soon',
           },
         ],
       },

--- a/templates/terraform/core/main.tf
+++ b/templates/terraform/core/main.tf
@@ -1,12 +1,4 @@
 terraform {
-  cloud {
-    organization = "organization"
-
-    workspaces {
-      name = "terraform_workspace"
-    }
-  }
-
   # Terraform version
   required_version = "1.5.5"
 }

--- a/templates/terraform/shared/main.tf
+++ b/templates/terraform/shared/main.tf
@@ -1,12 +1,4 @@
 terraform {
-  cloud {
-    organization = "organization"
-
-    workspaces {
-      name = "terraform_workspace"
-    }
-  }
-
   # Terraform version
   required_version = "1.5.5"
 }

--- a/test/matchers/file.ts
+++ b/test/matchers/file.ts
@@ -84,7 +84,8 @@ const toHaveDirectories = (
 const toHaveContentInFile = (
   projectDir: string,
   expectedFile: string,
-  expectedContent: string | string[]
+  expectedContent: string | string[],
+  options?: { ignoreSpaces?: boolean }
 ) => {
   let expectedContentArray: string[];
   if (!Array.isArray(expectedContent)) {
@@ -94,9 +95,15 @@ const toHaveContentInFile = (
   }
 
   const actualContent = readFileSync(`${projectDir}/${expectedFile}`, 'utf8');
-  const pass = expectedContentArray.every((content) =>
-    actualContent.includes(content)
-  );
+  const pass = expectedContentArray.every((content) => {
+    if (options?.ignoreSpaces) {
+      return actualContent
+        .replace(/\s/g, '')
+        .includes(content.replace(/\s/g, ''));
+    }
+
+    return actualContent.includes(content);
+  });
 
   return {
     pass,

--- a/test/matchers/index.d.ts
+++ b/test/matchers/index.d.ts
@@ -8,7 +8,8 @@ declare global {
       toHaveDirectories: (expectedDirectories: string[]) => R;
       toHaveContentInFile: (
         expectedFile: string,
-        expectedContent: string | string[]
+        expectedContent: string | string[],
+        options?: { ignoreSpaces?: boolean }
       ) => R;
     }
   }


### PR DESCRIPTION
- Close #191

## What happened 👀

- Add Terraform Cloud add-on
- Refactor Version Control add-on and make it isolated
- Remove `cloud` block in skeleton files
- Fix tests to work with the new add-ons

## Insight 📝

- We implemented the VersionControl prompt in the `generate` command file, but it will make the versionControl depends on that command. We need to make it isolated so that we can call it in anywhere
- In each add-on, I use the value `terraformCloudEnabled` instead of `enabled` because with this, we can test them easier by passing all values in a single mock object.

## Proof Of Work 📹

- Tests are passed
- The prompt is shown when creating a new project:
![2023-08-28 22 34 35](https://github.com/nimblehq/infrastructure-templates/assets/7344405/8e50ce22-4ef0-4c5a-a0fa-84064a20b87c)
