### PR TITLE
[#207] Fix: The tfsec fails due to aws-iam-no-policy-wildcards rule

### DIFF
--- a/templates/addons/aws/modules/iam_groups/main.tf
+++ b/templates/addons/aws/modules/iam_groups/main.tf
@@ -18,6 +18,7 @@ resource "aws_iam_group_policy_attachment" "admin_access" {
   policy_arn = data.aws_iam_policy.admin_access.arn
 }
 
+# tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_group_policy" "developer_allow_manage_own_credentials" {
   group  = aws_iam_group.developer.name
   policy = local.allow_manage_own_credentials

--- a/templates/addons/aws/modules/iam_groups/main.tf
+++ b/templates/addons/aws/modules/iam_groups/main.tf
@@ -18,6 +18,7 @@ resource "aws_iam_group_policy_attachment" "admin_access" {
   policy_arn = data.aws_iam_policy.admin_access.arn
 }
 
+# Policy from https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html
 # tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_group_policy" "developer_allow_manage_own_credentials" {
   group  = aws_iam_group.developer.name


### PR DESCRIPTION
- Close #207

## What happened 👀

- Actually, this is not a fix. We ignore it because we intend to do it

## Insight 📝

The policy that cause this error was copied from [this guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html)

## Proof Of Work 📹

|Before|After|
|------|------|
|![image](https://github.com/nimblehq/infrastructure-templates/assets/7344405/99ebd0f8-e9e9-46f2-9245-fa2770c91d31)|![image](https://github.com/nimblehq/infrastructure-templates/assets/7344405/94b16524-fe8b-49ba-88db-f16d6391a134)|