### PR TITLE
[#219] Fix: Cannot use 'import.meta' outside a module

### DIFF
--- a/.github/wiki/Getting-Started.md
+++ b/.github/wiki/Getting-Started.md
@@ -3,12 +3,12 @@
 The CLI can be installed globally or run directly with `npx`:
 
 ```bash
-npm install -g @nimblehq/infra-template
+npm install -g @nimblehq/infra-template@latest
 nimble-infra generate {project-name}
 
 # or
 
-npx @nimblehq/infra-template generate {project-name}
+npx @nimblehq/infra-template@latest generate {project-name}
 ```
 
 The CLI supports the following commands:

--- a/bin/run
+++ b/bin/run
@@ -6,5 +6,5 @@ process.env.NODE_ENV = 'production';
   // Register tsconfig-paths to allow importing without relative paths
   await import('tsconfig-paths').then((m) => m.register());
   const oclif = await import('@oclif/core');
-  await oclif.execute({ type: 'cjs', dir: import.meta.url });
+  await oclif.execute({ type: 'cjs', dir: __dirname });
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimblehq/infra-template",
-  "version": "2.0.1",
+  "version": "2.0.2-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimblehq/infra-template",
-      "version": "2.0.1",
+      "version": "2.0.2-beta.2",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimblehq/infra-template",
-  "version": "2.0.2-beta.2",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimblehq/infra-template",
-      "version": "2.0.2-beta.2",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblehq/infra-template",
-  "version": "2.0.1",
+  "version": "2.0.2-beta.2",
   "description": "Nimble Infrastructure Template generator",
   "author": "Nimblehq",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblehq/infra-template",
-  "version": "2.0.2-beta.2",
+  "version": "2.0.2",
   "description": "Nimble Infrastructure Template generator",
   "author": "Nimblehq",
   "bin": {

--- a/src/generators/addons/terraformCloud/index.ts
+++ b/src/generators/addons/terraformCloud/index.ts
@@ -1,5 +1,5 @@
-import dedent = require('dedent');
 import { prompt } from 'inquirer';
+import { dedent } from 'ts-dedent';
 
 import { GeneralOptions } from '@/commands/generate';
 import {

--- a/src/helpers/terraform.test.ts
+++ b/src/helpers/terraform.test.ts
@@ -34,7 +34,7 @@ describe('Terraform helper', () => {
         (runCommand as jest.Mock).mockRejectedValueOnce(
           new Error('terraform not found')
         );
-        const consoleSpy = jest.spyOn(global.console, 'error');
+        const consoleSpy = jest.spyOn(global.console, 'log');
 
         await detectTerraform();
 
@@ -65,11 +65,13 @@ describe('Terraform helper', () => {
         (runCommand as jest.Mock).mockRejectedValueOnce(
           new Error('terraform not found')
         );
-        const consoleSpy = jest.spyOn(global.console, 'error');
+        const consoleSpy = jest.spyOn(global.console, 'log');
 
         await formatCode('/');
 
-        expect(consoleSpy).toHaveBeenCalledWith(Error('terraform not found'));
+        expect(consoleSpy).toHaveBeenCalledWith(
+          "Couldn't format terraform code."
+        );
       });
     });
   });

--- a/src/helpers/terraform.ts
+++ b/src/helpers/terraform.ts
@@ -2,11 +2,11 @@ import { runCommand } from './childProcess';
 
 const detectTerraform = async () => {
   try {
-    await runCommand('which', ['terraform']);
+    await runCommand('terraform', []);
 
     return true;
   } catch (error) {
-    console.error('Terraform not found. Please install terraform.');
+    console.log('Terraform not found. Please install terraform.');
 
     return false;
   }
@@ -16,7 +16,7 @@ const formatCode = async (projectDir: string) => {
   try {
     await runCommand('terraform', ['fmt', '-recursive'], projectDir);
   } catch (error) {
-    console.error(error);
+    console.log("Couldn't format terraform code.");
   }
 };
 

--- a/src/hooks/postProcess.ts
+++ b/src/hooks/postProcess.ts
@@ -8,7 +8,7 @@ const postProcess = async (generalOptions: GeneralOptions) => {
       await formatCode(getProjectPath(generalOptions.projectName));
     }
   } catch (error) {
-    console.error(error);
+    console.log(error);
   }
 };
 

--- a/src/hooks/postProcess.ts
+++ b/src/hooks/postProcess.ts
@@ -8,7 +8,7 @@ const postProcess = async (generalOptions: GeneralOptions) => {
       await formatCode(getProjectPath(generalOptions.projectName));
     }
   } catch (error) {
-    console.log(error);
+    console.error(error);
   }
 };
 


### PR DESCRIPTION
- Close #219

## What happened 👀

- Fix Cannot use 'import.meta' outside a module
- Beautify the error message when `terraform not found`, it should not display the error details:
![image](https://github.com/nimblehq/infrastructure-templates/assets/7344405/d4b4463f-5f46-4e82-a920-ca0b4fd069db)


## Insight 📝

This was a bug when upgrading the OCLIF library, as we were using the ES module syntax in the code. You can check the #219 content to get more details.

## Proof Of Work 📹

Try publishing and it works:
`npx @nimblehq/infra-template@2.0.2-beta.4 generate demo-project`

![image](https://github.com/nimblehq/infrastructure-templates/assets/7344405/961499a0-07dc-46b9-a1e0-7f88367a5dd8)

