### PR TITLE
[#145] Add a workflow to draft a new release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,12 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '⭐ Features'
+    label: 'type : feature'
+  - title: '🧹 Chores'
+    label: 'type : chore'
+  - title: '🐞 Bugs'
+    label: 'type : bug'
+change-template: '- $TITLE'
+template: |
+  $CHANGES

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -3,7 +3,7 @@ name: Draft a new release
 on:
   push:
     branches:
-      - feature/gh-145-add-draft-new-release-workflow
+      - main
 
 env:
   VERSION_FILE: ./package.json

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -3,7 +3,7 @@ name: Draft a new release
 on:
   push:
     branches:
-      - main
+      - feature/gh-145-add-draft-new-release-workflow
 
 env:
   VERSION_FILE: ./package.json

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -1,0 +1,32 @@
+name: Draft a new release
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  VERSION_FILE: ./package.json
+
+jobs:
+  draft-new-release:
+    name: Draft a new release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get current version
+        id: current_version
+        run: |
+          currentVersion=$(node -p -e "require('${{ env.VERSION_FILE }}').version")
+          echo "version=$currentVersion" >> $GITHUB_OUTPUT
+
+      - name: Draft a new release
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          version: ${{ steps.current_version.outputs.version }}


### PR DESCRIPTION
- Close #145

## What happened 👀

- Use https://github.com/release-drafter/release-drafter to draft a new release after merged to main
- The config is copied from https://github.com/nimblehq/android-templates/blob/develop/.github/release-drafter-config.yml

## Insight 📝

N/A

## Proof Of Work 📹

Workflow run: https://github.com/nimblehq/infrastructure-templates/actions/runs/6609598250
![image](https://github.com/nimblehq/infrastructure-templates/assets/7344405/b7b2813c-4546-42d8-8062-a587c38feb57)

Drafted release: https://github.com/nimblehq/infrastructure-templates/releases/tag/untagged-b1ea34b6ada36c0166d9
