### PR TITLE
[Chore] Bump version to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimblehq/infra-template",
-  "version": "2.0.2",
+  "version": "2.2.0",
   "description": "Nimble Infrastructure Template generator",
   "author": "Nimblehq",
   "bin": {


### PR DESCRIPTION
## What happened 👀

- Bump version to 2.2.0
- The previous PR was merged to wrong branch

## Insight 📝

N/A

## Proof Of Work 📹

On the Files changed tab