### PR TITLE
[#246] Fix: Wrong syntax for the policy document of full_iam_access_policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimblehq/infra-template",
-  "version": "2.0.2",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimblehq/infra-template",
-      "version": "2.0.2",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^2",

--- a/templates/addons/aws/modules/iam_groups/data.tf
+++ b/templates/addons/aws/modules/iam_groups/data.tf
@@ -1,10 +1,10 @@
 locals {
   # Comes from https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html
-  # This policy allows users to view and edit their own passwords, access keys, MFA devices, X.509 certificates, SSH keys, and Git credentials. 
-  # In addition, users are required to set up and authenticate using MFA before performing any other operations in AWS. 
-  # It also means this policy does NOT allow users to reset a password while signing in to the AWS Management Console for the first time. 
+  # This policy allows users to view and edit their own passwords, access keys, MFA devices, X.509 certificates, SSH keys, and Git credentials.
+  # In addition, users are required to set up and authenticate using MFA before performing any other operations in AWS.
+  # It also means this policy does NOT allow users to reset a password while signing in to the AWS Management Console for the first time.
   # They must first set up their MFA because allowing users to change their password without MFA can be a security risk.
-  # 
+  #
   # The following actions are added to the initial policy from AWS
   # - iam:GetLoginProfile: allows the IAM user to view their account information on the security page.
   # - iam:GetAccessKeyLastUsed: allows the IAM user to view the last time their access key was used.
@@ -123,13 +123,13 @@ locals {
   # For the bot account
   # It must be able to manage policies during terraform apply & create/delete users, permissions, etc. during terraform apply
   full_iam_access_policy = jsonencode({
-    version = "2012-10-17"
-    statement = [
+    Version = "2012-10-17"
+    Statement = [
       {
-        sid       = "AllowManageRoleAndPolicy"
-        effect    = "Allow"
-        resources = ["arn:aws:iam::*"]
-        actions   = ["iam:*"]
+        Sid      = "AllowManageRoleAndPolicy"
+        Effect   = "Allow"
+        Resource = ["arn:aws:iam::*"]
+        Action   = ["iam:*"]
       }
     ]
   })

--- a/templates/addons/aws/modules/iam_groups/main.tf
+++ b/templates/addons/aws/modules/iam_groups/main.tf
@@ -35,7 +35,10 @@ resource "aws_iam_group_policy_attachment" "bot_power_user_access" {
   policy_arn = data.aws_iam_policy.power_user_access.arn
 }
 
+# This IAM policy is needed for the bot account to manage IAM users & groups
+# tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_group_policy" "bot_full_iam_access" {
+  name   = "AllowFullIamAccess"
   group  = aws_iam_group.bot.name
   policy = local.full_iam_access_policy
 }


### PR DESCRIPTION
- Close #246

## What happened 👀

Fix syntax for IAM access policy.

The fix based on this PR: https://github.com/Jollibee-Foods-Corporation/smashburger-infrastructure-aws/pull/5 (you need JFC repo access for it).

## Proof Of Work 📹

Before the fix TF plan stage was passed, but on apply stage we had an error:

![image](https://github.com/nimblehq/infrastructure-templates/assets/475367/9554b6a8-35ec-44c5-b952-64443247b4c8)

After the fix the plan can be applied correctly:

![image](https://github.com/nimblehq/infrastructure-templates/assets/475367/6a4a38dd-fbaa-4838-bf33-00ff9d7b5a90)