### PR TITLE
[#254] Prevent creating the login credential for IAM bot account

### DIFF
--- a/templates/addons/aws/modules/iam_groups/data.tf
+++ b/templates/addons/aws/modules/iam_groups/data.tf
@@ -120,7 +120,7 @@ locals {
     ]
   })
 
-  # For the bot account
+  # For the infra-service-account account
   # It must be able to manage policies during terraform apply & create/delete users, permissions, etc. during terraform apply
   full_iam_access_policy = jsonencode({
     Version = "2012-10-17"

--- a/templates/addons/aws/modules/iam_groups/main.tf
+++ b/templates/addons/aws/modules/iam_groups/main.tf
@@ -4,8 +4,8 @@ resource "aws_iam_group" "admin" {
 }
 
 #tfsec:ignore:aws-iam-enforce-group-mfa
-resource "aws_iam_group" "bot" {
-  name = "Bot-group"
+resource "aws_iam_group" "infra-service-account" {
+  name = "Infra-service-account-group"
 }
 
 #tfsec:ignore:aws-iam-enforce-group-mfa
@@ -30,15 +30,15 @@ resource "aws_iam_group_policy_attachment" "developer_power_user_access" {
   policy_arn = data.aws_iam_policy.power_user_access.arn
 }
 
-resource "aws_iam_group_policy_attachment" "bot_power_user_access" {
-  group      = aws_iam_group.bot.name
+resource "aws_iam_group_policy_attachment" "infra_service_account_power_user_access" {
+  group      = aws_iam_group.infra-service-account.name
   policy_arn = data.aws_iam_policy.power_user_access.arn
 }
 
-# This IAM policy is needed for the bot account to manage IAM users & groups
+# This IAM policy is needed for the infra-service-account account to manage IAM users & groups
 # tfsec:ignore:aws-iam-no-policy-wildcards
-resource "aws_iam_group_policy" "bot_full_iam_access" {
+resource "aws_iam_group_policy" "infra_service_account_full_iam_access" {
   name   = "AllowFullIamAccess"
-  group  = aws_iam_group.bot.name
+  group  = aws_iam_group.infra-service-account.name
   policy = local.full_iam_access_policy
 }

--- a/templates/addons/aws/modules/iam_groups/outputs.tf
+++ b/templates/addons/aws/modules/iam_groups/outputs.tf
@@ -8,7 +8,7 @@ output "developer_group" {
   value       = aws_iam_group.developer.name
 }
 
-output "bot_group" {
-  description = "IAM Group with bot permissions"
-  value       = aws_iam_group.bot.name
+output "infra_service_account_group" {
+  description = "IAM Group with infra-service-account permissions"
+  value       = aws_iam_group.infra-service-account.name
 }


### PR DESCRIPTION
- Close #254

## What happened 👀

List of implemented improvements:
- Disable console login for service account (`has_login = false`). It is unnecessary for service account to have console login and exposes more risk. Credentials that will be used by service account can be generated through admin account.
- Rename `bot` to `infra-service-account`, since this name is more accurate describe why we need this account
- Set `depends_on` attribute to `group_membership`. Without `depends_on` there was an error when we tried to add new user, it said that user wasn't created yet.
- Refactor `group_membership` to be set through forloop, to make it easier change attributes (otherwise we had to set same `depends_on` for all three memberships).

## Proof Of Work 📹

TF plan can be run and applied without any errors:

<img width="1100" alt="image" src="https://github.com/nimblehq/infrastructure-templates/assets/475367/b0b685fe-1b1a-4c9d-bb19-098b070b24fa">

