### PR TITLE
[#274] Add project name to the IAM group names

### DIFF
--- a/src/commands/generate/index.test.ts
+++ b/src/commands/generate/index.test.ts
@@ -12,7 +12,8 @@ describe('Generator command', () => {
   describe('given valid options', () => {
     describe('given provider is AWS', () => {
       describe('given infrastructure type is blank', () => {
-        const projectDir = 'aws-blank-test';
+        const originalDirectoryName = 'AWS blank test';
+        const processedDirectoryName = 'aws-blank-test';
         const stdoutSpy = jest.spyOn(process.stdout, 'write');
 
         beforeAll(async () => {
@@ -23,18 +24,18 @@ describe('Generator command', () => {
             terraformCloudEnabled: false,
           });
 
-          await Generator.run([projectDir]);
+          await Generator.run([originalDirectoryName]);
         });
 
         afterAll(() => {
           jest.clearAllMocks();
-          remove('/', projectDir);
+          remove('/', processedDirectoryName);
         });
 
         it('creates expected directories', () => {
           const expectedDirectories = ['core/', 'shared/'];
 
-          expect(projectDir).toHaveDirectories(expectedDirectories);
+          expect(processedDirectoryName).toHaveDirectories(expectedDirectories);
         });
 
         it('creates expected files', () => {
@@ -51,7 +52,7 @@ describe('Generator command', () => {
             'shared/outputs.tf',
           ];
 
-          expect(projectDir).toHaveFiles(expectedFiles);
+          expect(processedDirectoryName).toHaveFiles(expectedFiles);
         });
 
         it('displays the success message', () => {
@@ -62,6 +63,17 @@ describe('Generator command', () => {
 
         it('calls postProcess hook', () => {
           expect(postProcess).toHaveBeenCalledTimes(1);
+        });
+
+        it('contains processed project name in main files', () => {
+          const mainFiles = ['shared/main.tf', 'core/main.tf'];
+          mainFiles.forEach((fileName) => {
+            expect(processedDirectoryName).toHaveContentInFile(
+              fileName,
+              `project_name = "${processedDirectoryName}"`,
+              { ignoreSpaces: true }
+            );
+          });
         });
       });
 

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -47,17 +47,16 @@ export default class Generator extends Command {
 
     const generalPrompt = await prompt<GeneralOptions>([...providerChoices]);
 
+    const projectName = args.projectName.toLowerCase().replace(/\s/g, '-');
     const generalOptions: GeneralOptions = {
-      projectName: args.projectName,
+      projectName: projectName,
       provider: generalPrompt.provider,
     };
 
     await this.generate(generalOptions);
     await postProcess(generalOptions);
 
-    ux.info(
-      `The infrastructure code was generated at '${generalOptions.projectName}'`
-    );
+    ux.info(`The infrastructure code was generated at '${args.projectName}'`);
   }
 
   private async generate(generalOptions: GeneralOptions) {

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -46,7 +46,6 @@ export default class Generator extends Command {
     const { args } = await this.parse(Generator);
 
     const generalPrompt = await prompt<GeneralOptions>([...providerChoices]);
-
     const projectName = args.projectName.toLowerCase().replace(/\s/g, '-');
     const generalOptions: GeneralOptions = {
       projectName: projectName,
@@ -56,7 +55,9 @@ export default class Generator extends Command {
     await this.generate(generalOptions);
     await postProcess(generalOptions);
 
-    ux.info(`The infrastructure code was generated at '${args.projectName}'`);
+    ux.info(
+      `The infrastructure code was generated at '${generalOptions.projectName}'`
+    );
   }
 
   private async generate(generalOptions: GeneralOptions) {

--- a/src/generators/addons/aws/modules/core/iamUserAndGroup.ts
+++ b/src/generators/addons/aws/modules/core/iamUserAndGroup.ts
@@ -28,6 +28,8 @@ const iamVariablesContent = dedent`
 const iamGroupsModuleContent = dedent`
   module "iam_groups" {
     source = "../modules/iam_groups"
+
+    project_name = local.project_name
   }`;
 
 const iamUsersModuleContent = dedent`

--- a/src/generators/terraform/index.ts
+++ b/src/generators/terraform/index.ts
@@ -12,11 +12,10 @@ const applyTerraformCore = async (generalOptions: GeneralOptions) => {
 
   copy('terraform/', '.', projectName);
 
-  // Use projectName to append the Namespace local in the main.tf file
   const coreLocalsContent = dedent`
       locals {
         project_name  = "${projectName}"
-        env_namespace = "${projectName}-\${var.environment}"
+        env_namespace = "\${local.project_name}-\${var.environment}"
       }`;
 
   appendToFile(INFRA_CORE_MAIN_PATH, coreLocalsContent, projectName);

--- a/src/generators/terraform/index.ts
+++ b/src/generators/terraform/index.ts
@@ -15,6 +15,7 @@ const applyTerraformCore = async (generalOptions: GeneralOptions) => {
   // Use projectName to append the Namespace local in the main.tf file
   const coreLocalsContent = dedent`
       locals {
+        project_name  = "${projectName}"
         env_namespace = "${projectName}-\${var.environment}"
       }`;
 

--- a/templates/addons/aws/modules/iam_groups/main.tf
+++ b/templates/addons/aws/modules/iam_groups/main.tf
@@ -1,16 +1,16 @@
 #tfsec:ignore:aws-iam-enforce-group-mfa
 resource "aws_iam_group" "admin" {
-  name = "Admin-group"
+  name = "${var.project_name}-admin-group"
 }
 
 #tfsec:ignore:aws-iam-enforce-group-mfa
 resource "aws_iam_group" "infra-service-account" {
-  name = "Infra-service-account-group"
+  name = "${var.project_name}-infra-service-account-group"
 }
 
 #tfsec:ignore:aws-iam-enforce-group-mfa
 resource "aws_iam_group" "developer" {
-  name = "Developer-group"
+  name = "${var.project_name}-developer-group"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_access" {

--- a/templates/addons/aws/modules/iam_groups/variables.tf
+++ b/templates/addons/aws/modules/iam_groups/variables.tf
@@ -1,0 +1,4 @@
+variable "project_name" {
+  description = "The name of the project"
+  type        = string
+}


### PR DESCRIPTION
- Close #274

## What happened 👀

- Add project name to the IAM group name to make sure that it doesn't conflict with other deployed projects
- Convert project name to lowercase and replace whitespaces with `-` to make sure that we can use project name as variable

## Proof Of Work 📹

Before the fix, I couldn't deploy the template to the company's AWS account since the groups had already been created by the Nexus project:
![image](https://github.com/nimblehq/infrastructure-templates/assets/475367/666c843a-9b7a-4b6f-9c54-c596939b28c8)

After the fix groups were created:
![image](https://github.com/nimblehq/infrastructure-templates/assets/475367/a6757690-d32a-4a8f-80e0-0cde586a0f2c)

