### PR TITLE
[#292] Update TF version and GH actions versions

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -25,7 +25,7 @@ jobs:
           echo "version=$currentVersion" >> $GITHUB_OUTPUT
 
       - name: Draft a new release
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -112,7 +112,7 @@ jobs:
         run: npm install
 
       - name: Create a new pull request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ github.token }}
           branch: chore/bump-version-to-${{ steps.next-version.outputs.version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,24 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup node and restore cached dependencies
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18.x'
-          cache: 'npm'
+      - name: Install dependencies in .tool-versions
+        uses: asdf-vm/actions/install@v3
 
       - name: Install dependencies
         run: npm ci
 
       - name: Run linters
         run: npm run lint
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.5.5
 
       - name: Terraform fmt
         run: terraform fmt -check -recursive

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/test-generated-project.yml
+++ b/.github/workflows/test-generated-project.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-env:
-  TERRAFORM_VERSION: "1.5.5"
-  TFSEC_VERSION: "v1.28.1"
-
 jobs:
   test:
     name: Run Tests Generated Project
@@ -17,11 +13,8 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18.x'
-          cache: 'npm'
+      - name: Install dependencies in .tool-versions
+        uses: asdf-vm/actions/install@v3
 
       - name: Cache Node npm
         id: cache-nodemodules
@@ -38,9 +31,6 @@ jobs:
 
       - name: Generate project
         run: . ./scripts/generateAdvancedAWS.sh
-
-      - name: Install dependencies from .tool-versions
-        uses: asdf-vm/actions/install@v2
 
       - name: Run Terraform format
         run: terraform fmt -recursive -check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,4 @@ jobs:
         with:
           name: jest-coverage
           path: coverage/coverage-final.json
+          retention-days: 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -37,7 +37,7 @@ jobs:
         run: npm run test '--ignore-scripts' -- --coverage --ci
 
       - name: Upload test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jest-coverage
           path: coverage/coverage-final.json

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 18.12.1
-terraform 1.5.5
+terraform 1.8.3
 trivy 0.47.0

--- a/templates/addons/versionControl/github/.github/workflows/lint.yml
+++ b/templates/addons/versionControl/github/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 

--- a/templates/terraform/.tool-versions
+++ b/templates/terraform/.tool-versions
@@ -1,2 +1,2 @@
-terraform 1.5.5
+terraform 1.8.3
 trivy 0.47.0

--- a/templates/terraform/core/main.tf
+++ b/templates/terraform/core/main.tf
@@ -1,4 +1,4 @@
 terraform {
   # Terraform version
-  required_version = "1.5.5"
+  required_version = "1.8.3"
 }

--- a/templates/terraform/shared/main.tf
+++ b/templates/terraform/shared/main.tf
@@ -1,4 +1,4 @@
 terraform {
   # Terraform version
-  required_version = "1.5.5"
+  required_version = "1.8.3"
 }


### PR DESCRIPTION
- Close #292

## What happened 👀

- Upgrade TF to 1.8.3 version
- Upgrade GH actions to latest versions
- Install TF and node through asdf instead of manual installation

## Proof Of Work 📹

CI is green.
