### PR TITLE
[#316] Add VPC flow log module as an optional module

### DIFF
--- a/.github/wiki/Security.md
+++ b/.github/wiki/Security.md
@@ -23,4 +23,3 @@ To add security features to your infrastructure:
 1. Run the infrastructure generator
 2. Select "Complete infrastructure (VPC + ECR + RDS + S3 + FARGATE + Cloudwatch + Security groups + ALB)" when prompted for infrastructure type
 3. Choose "Yes" when asked "Do you want to create (VPC Flow Logs + CloudTrail) to enhance security posture and compliance?"
-

--- a/.github/wiki/Security.md
+++ b/.github/wiki/Security.md
@@ -1,0 +1,26 @@
+# Security
+
+This document provides an overview of the security modules available in the infrastructure templates to help enhance your AWS infrastructure security posture.
+
+## Available Security Modules
+
+### VPC Flow Log
+
+The VPC Flow Log module captures network traffic information in your VPC to help with security monitoring and network analysis.
+
+#### Overview
+
+VPC Flow Logs capture information about IP traffic going to and from network interfaces in your VPC. This module:
+
+- **Captures network flows**: Records detailed information about network traffic patterns in your VPC
+- **Stores logs in S3**: Saves all captured flow logs securely in an Amazon S3 bucket with configurable retention
+- **Enables querying via Athena**: Provides ready-to-use AWS Athena integration for analyzing log data using SQL queries
+
+## Getting Started
+
+To add security features to your infrastructure:
+
+1. Run the infrastructure generator
+2. Select "Complete infrastructure (VPC + ECR + RDS + S3 + FARGATE + Cloudwatch + Security groups + ALB)" when prompted for infrastructure type
+3. Choose "Yes" when asked "Do you want to create (VPC Flow Logs + CloudTrail) to enhance security posture and compliance?"
+

--- a/.github/wiki/_Sidebar.md
+++ b/.github/wiki/_Sidebar.md
@@ -12,6 +12,7 @@
 - [[Add a new CLI command | Add new command]]
 - [[Add New Addon or Module | Add new addon module]]
 - [[Using The Generator As Reference]]
+- [[Security]]
 - [[Testing]]
 - [[Modify the Infrastructure Diagram | Modify infra diagram]]
 - [[Publishing]]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 18.12.1
-terraform 1.13.3
-trivy 0.47.0
+terraform 1.14.6
+trivy 0.69.2

--- a/src/generators/addons/aws/advanced.test.ts
+++ b/src/generators/addons/aws/advanced.test.ts
@@ -11,6 +11,7 @@ import {
   applyAwsRds,
   applyAwsS3,
   applyAwsSsm,
+  applyAwsVpcFlowLog,
 } from './modules';
 
 jest.mock('./modules');
@@ -64,6 +65,38 @@ describe('AWS advanced template', () => {
 
     it('applies ECS add-on', () => {
       expect(applyAwsEcs).toHaveBeenCalledWith(options);
+    });
+
+    describe('given enabledSecurityFeatures is not set', () => {
+      it('does NOT apply VPC Flow Log add-on', () => {
+        expect(applyAwsVpcFlowLog).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('given enabledSecurityFeatures is true', () => {
+      const optionsEnabledSecurityFeatures: AwsOptions = {
+        projectName: projectDir,
+        provider: 'aws',
+        infrastructureType: 'advanced',
+        awsRegion: 'ap-southeast-1',
+        enabledSecurityFeatures: true,
+      };
+
+      beforeAll(async () => {
+        jest.clearAllMocks();
+        await applyAdvancedTemplate(optionsEnabledSecurityFeatures);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+        remove('/', projectDir);
+      });
+
+      it('applies VPC Flow Log add-on when flag is set', () => {
+        expect(applyAwsVpcFlowLog).toHaveBeenCalledWith(
+          optionsEnabledSecurityFeatures
+        );
+      });
     });
   });
 });

--- a/src/generators/addons/aws/advanced.test.ts
+++ b/src/generators/addons/aws/advanced.test.ts
@@ -24,6 +24,8 @@ describe('AWS advanced template', () => {
       provider: 'aws',
       infrastructureType: 'advanced',
       awsRegion: 'ap-southeast-1',
+      addonModules: [],
+      enabledSecurityFeatures: false,
     };
 
     beforeAll(async () => {
@@ -74,28 +76,53 @@ describe('AWS advanced template', () => {
     });
 
     describe('given enabledSecurityFeatures is true', () => {
-      const optionsEnabledSecurityFeatures: AwsOptions = {
-        projectName: projectDir,
-        provider: 'aws',
-        infrastructureType: 'advanced',
-        awsRegion: 'ap-southeast-1',
-        enabledSecurityFeatures: true,
-      };
+      describe('given addonModules includes vpcFlowLog', () => {
+        const optionsEnabledSecurityFeatures: AwsOptions = {
+          projectName: projectDir,
+          provider: 'aws',
+          infrastructureType: 'advanced',
+          awsRegion: 'ap-southeast-1',
+          enabledSecurityFeatures: true,
+          addonModules: ['vpcFlowLog'],
+        };
 
-      beforeAll(async () => {
-        jest.clearAllMocks();
-        await applyAdvancedTemplate(optionsEnabledSecurityFeatures);
+        beforeAll(async () => {
+          jest.clearAllMocks();
+          await applyAdvancedTemplate(optionsEnabledSecurityFeatures);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+          remove('/', projectDir);
+        });
+
+        it('applies VPC Flow Log add-on when flag is set', () => {
+          expect(applyAwsVpcFlowLog).toHaveBeenCalledWith(
+            optionsEnabledSecurityFeatures
+          );
+        });
       });
+      describe('given addonModules does NOT include vpcFlowLog', () => {
+        const optionsEnabledSecurityFeaturesWithoutVpcFlowLog: AwsOptions = {
+          projectName: projectDir,
+          provider: 'aws',
+          infrastructureType: 'advanced',
+          awsRegion: 'ap-southeast-1',
+          enabledSecurityFeatures: true,
+          addonModules: [], // No vpcFlowLog
+        };
 
-      afterAll(() => {
-        jest.clearAllMocks();
-        remove('/', projectDir);
-      });
+        afterAll(() => {
+          jest.clearAllMocks();
+          remove('/', projectDir);
+        });
 
-      it('applies VPC Flow Log add-on when flag is set', () => {
-        expect(applyAwsVpcFlowLog).toHaveBeenCalledWith(
-          optionsEnabledSecurityFeatures
-        );
+        it('does NOT apply VPC Flow Log add-on when flag is set but module is not included', async () => {
+          await applyAdvancedTemplate(
+            optionsEnabledSecurityFeaturesWithoutVpcFlowLog
+          );
+          expect(applyAwsVpcFlowLog).not.toHaveBeenCalled();
+        });
       });
     });
   });

--- a/src/generators/addons/aws/advanced.ts
+++ b/src/generators/addons/aws/advanced.ts
@@ -8,6 +8,7 @@ import {
   applyAwsRds,
   applyAwsS3,
   applyAwsSsm,
+  applyAwsVpcFlowLog,
 } from './modules';
 
 const applyAdvancedTemplate = async (options: AwsOptions) => {
@@ -19,6 +20,10 @@ const applyAdvancedTemplate = async (options: AwsOptions) => {
   await applyAwsCloudwatch(options);
   await applyAwsS3(options);
   await applyAwsSsm(options);
+
+  if (options.enabledSecurityFeatures) {
+    await applyAwsVpcFlowLog(options);
+  }
 };
 
 export { applyAdvancedTemplate };

--- a/src/generators/addons/aws/advanced.ts
+++ b/src/generators/addons/aws/advanced.ts
@@ -21,8 +21,17 @@ const applyAdvancedTemplate = async (options: AwsOptions) => {
   await applyAwsS3(options);
   await applyAwsSsm(options);
 
-  if (options.enabledSecurityFeatures) {
-    await applyAwsVpcFlowLog(options);
+  if (options?.addonModules && options?.addonModules.length > 0) {
+    await Promise.all(
+      options.addonModules.map((module) => {
+        switch (module) {
+          case 'vpcFlowLog':
+            return applyAwsVpcFlowLog(options);
+          default:
+            throw new Error(`Module ${module} has not been implemented!`);
+        }
+      })
+    );
   }
 };
 

--- a/src/generators/addons/aws/dependencies.ts
+++ b/src/generators/addons/aws/dependencies.ts
@@ -13,6 +13,7 @@ import {
   applyAwsSecurityGroup,
   applyAwsSsm,
   applyAwsVpc,
+  applyAwsVpcFlowLog,
 } from '@/generators/addons/aws/modules';
 import { containsContent, isExisting } from '@/helpers/file';
 
@@ -84,6 +85,12 @@ const AWS_MODULES: Record<AwsModuleName | string, AwsModule> = {
     path: 'modules/ssm',
     mainContent: 'module "ssm"',
     applyModuleFunction: (options: AwsOptions) => applyAwsSsm(options),
+  },
+  vpcFlowLog: {
+    name: 'vpcFlowLog',
+    path: 'modules/vpc_flow_log',
+    mainContent: 'module "vpc_flow_log"',
+    applyModuleFunction: (options: AwsOptions) => applyAwsVpcFlowLog(options),
   },
 };
 

--- a/src/generators/addons/aws/index.ts
+++ b/src/generators/addons/aws/index.ts
@@ -12,6 +12,12 @@ import {
   applyAwsVpc,
 } from './modules';
 
+type AwsOptions = GeneralOptions & {
+  infrastructureType?: 'blank' | 'advanced';
+  awsRegion?: string;
+  enabledSecurityFeatures?: boolean;
+};
+
 const awsChoices = [
   {
     type: 'list',
@@ -31,17 +37,20 @@ const awsChoices = [
     ],
   },
   {
+    type: 'confirm',
+    name: 'enabledSecurityFeatures',
+    message:
+      'Do you want to create (VPC Flow Logs + CloudTrail) to enhance security posture and compliance?',
+    default: false,
+    when: (answers: AwsOptions) => answers.infrastructureType === 'advanced',
+  },
+  {
     type: 'input',
     name: 'awsRegion',
     default: AWS_DEFAULT_REGION,
     message: 'Which AWS Region do you choose?',
   },
 ];
-
-type AwsOptions = GeneralOptions & {
-  infrastructureType?: 'blank' | 'advanced';
-  awsRegion?: string;
-};
 
 const applyProviderAndRegion = async (options: AwsOptions) => {
   await applyTerraformAwsProvider(options);
@@ -52,10 +61,12 @@ const generateAwsTemplate = async (
   generalOptions: GeneralOptions
 ): Promise<void> => {
   const awsOptionsPrompt = await prompt(awsChoices);
+
   const awsOptions: AwsOptions = {
     ...generalOptions,
     infrastructureType: awsOptionsPrompt.infrastructureType,
     awsRegion: awsOptionsPrompt.awsRegion,
+    enabledSecurityFeatures: awsOptionsPrompt.enabledSecurityFeatures,
   };
 
   switch (awsOptions.infrastructureType) {

--- a/src/generators/addons/aws/index.ts
+++ b/src/generators/addons/aws/index.ts
@@ -16,6 +16,7 @@ type AwsOptions = GeneralOptions & {
   infrastructureType?: 'blank' | 'advanced';
   awsRegion?: string;
   enabledSecurityFeatures?: boolean;
+  addonModules?: string[];
 };
 
 const awsChoices = [
@@ -39,10 +40,27 @@ const awsChoices = [
   {
     type: 'confirm',
     name: 'enabledSecurityFeatures',
-    message:
-      'Do you want to create (VPC Flow Logs + CloudTrail) to enhance security posture and compliance?',
+    message: 'Do you want to add more modules(VPC Flow Logs, CloudTrail)?',
     default: false,
     when: (answers: AwsOptions) => answers.infrastructureType === 'advanced',
+  },
+  {
+    type: 'checkbox',
+    name: 'addonModules',
+    message: 'Which security features do you want to add?',
+    choices: [
+      {
+        key: 'vpcFlowLog',
+        value: 'vpcFlowLog',
+        name: 'VPC Flow Logs',
+      },
+      {
+        key: 'cloudTrail',
+        value: 'cloudTrail',
+        name: 'CloudTrail',
+      },
+    ],
+    when: (answers: AwsOptions) => answers.enabledSecurityFeatures,
   },
   {
     type: 'input',
@@ -66,7 +84,7 @@ const generateAwsTemplate = async (
     ...generalOptions,
     infrastructureType: awsOptionsPrompt.infrastructureType,
     awsRegion: awsOptionsPrompt.awsRegion,
-    enabledSecurityFeatures: awsOptionsPrompt.enabledSecurityFeatures,
+    addonModules: awsOptionsPrompt.addonModules,
   };
 
   switch (awsOptions.infrastructureType) {

--- a/src/generators/addons/aws/modules/alb.ts
+++ b/src/generators/addons/aws/modules/alb.ts
@@ -11,9 +11,8 @@ import {
   INFRA_CORE_MAIN_PATH,
   INFRA_CORE_OUTPUTS_PATH,
   INFRA_CORE_VARIABLES_PATH,
-  MODULES_LOCALS_INDICATOR,
 } from '@/generators/terraform/constants';
-import { appendToFile, copy, injectToFile } from '@/helpers/file';
+import { appendToFile, copy } from '@/helpers/file';
 
 import {
   AWS_SECURITY_GROUP_MAIN_PATH,

--- a/src/generators/addons/aws/modules/alb.ts
+++ b/src/generators/addons/aws/modules/alb.ts
@@ -11,8 +11,9 @@ import {
   INFRA_CORE_MAIN_PATH,
   INFRA_CORE_OUTPUTS_PATH,
   INFRA_CORE_VARIABLES_PATH,
+  MODULES_LOCALS_INDICATOR,
 } from '@/generators/terraform/constants';
-import { appendToFile, copy } from '@/helpers/file';
+import { appendToFile, copy, injectToFile } from '@/helpers/file';
 
 import {
   AWS_SECURITY_GROUP_MAIN_PATH,

--- a/src/generators/addons/aws/modules/index.ts
+++ b/src/generators/addons/aws/modules/index.ts
@@ -11,6 +11,7 @@ import applyAwsEcs from './ecs';
 import applyAwsRds from './rds';
 import applyAwsS3 from './s3';
 import applyAwsSsm from './ssm';
+import applyAwsVpcFlowLog from './vpcFlowLog';
 
 export {
   applyAwsAlb,
@@ -26,4 +27,5 @@ export {
   applyAwsSecurityGroup,
   applyAwsSsm,
   applyAwsVpc,
+  applyAwsVpcFlowLog,
 };

--- a/src/generators/addons/aws/modules/vpcFlowLog.test.ts
+++ b/src/generators/addons/aws/modules/vpcFlowLog.test.ts
@@ -1,0 +1,66 @@
+import { AwsOptions } from '@/generators/addons/aws';
+import { applyTerraformCore } from '@/generators/terraform';
+import { remove } from '@/helpers/file';
+
+import applyTerraformAwsProvider from './core/provider';
+import applyAwsVpcFlowLog, {
+  vpcFlowLogModuleContent,
+  vpcFlowLogVariablesContent,
+} from './vpcFlowLog';
+
+jest.mock('inquirer', () => {
+  return {
+    prompt: jest.fn().mockResolvedValue({ apply: true }),
+  };
+});
+
+describe('VPC Flow Log add-on', () => {
+  describe('given valid AWS options', () => {
+    const projectDir = 'vpc-flow-log-addon-test';
+
+    beforeAll(async () => {
+      const awsOptions: AwsOptions = {
+        projectName: projectDir,
+        provider: 'aws',
+        infrastructureType: 'advanced',
+      };
+
+      await applyTerraformCore(awsOptions);
+      await applyTerraformAwsProvider(awsOptions);
+      await applyAwsVpcFlowLog(awsOptions);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+      remove('/', projectDir);
+    });
+
+    it('creates expected files', () => {
+      const expectedFiles = [
+        'core/main.tf',
+        'core/providers.tf',
+        'core/outputs.tf',
+        'core/variables.tf',
+        'modules/vpc_flow_log/main.tf',
+        'modules/vpc_flow_log/variables.tf',
+        'modules/vpc_flow_log/outputs.tf',
+      ];
+
+      expect(projectDir).toHaveFiles(expectedFiles);
+    });
+
+    it('adds vpc_flow_log module to main.tf', () => {
+      expect(projectDir).toHaveContentInFile(
+        'core/main.tf',
+        vpcFlowLogModuleContent
+      );
+    });
+
+    it('adds vpc_flow_log variables to variables.tf', () => {
+      expect(projectDir).toHaveContentInFile(
+        'core/variables.tf',
+        vpcFlowLogVariablesContent
+      );
+    });
+  });
+});

--- a/src/generators/addons/aws/modules/vpcFlowLog.ts
+++ b/src/generators/addons/aws/modules/vpcFlowLog.ts
@@ -14,7 +14,7 @@ import { appendToFile, copy } from '@/helpers/file';
 
 import { AWS_TEMPLATE_PATH } from '../constants';
 
-const vpcFlowLogLocalesContent = dedent`
+const vpcFlowLogLocalsContent = dedent`
   ### Begin VPC Flow Log ###
   locals {
     vpc_flow_log_s3_bucket_policy = {
@@ -74,6 +74,7 @@ const vpcFlowLogLocalesContent = dedent`
         }
       ]
     }
+    vpc_flow_log_query_year_ranges = "\${formatdate("YYYY", timestamp())},\${formatdate("YYYY", timestamp()) + 5}"
   }
   ### End VPC Flow Log ###`;
 
@@ -81,7 +82,7 @@ const vpcFlowLogVariablesContent = dedent`
   variable "vpc_flow_log_retention_days" {
     description = "The number of days to retain VPC Flow Logs in S3"
     type        = number
-    default     = 90
+    default     = 30
   }`;
 
 const vpcFlowLogModuleContent = dedent`
@@ -90,7 +91,7 @@ const vpcFlowLogModuleContent = dedent`
 
     env_namespace    = local.env_namespace
     bucket_name      = "\${local.env_namespace}-flow-logs-\${data.aws_caller_identity.current.account_id}"
-    force_destroy    = true
+    force_destroy    = false
     object_ownership = "BucketOwnerPreferred"
   }
 
@@ -108,6 +109,7 @@ const vpcFlowLogModuleContent = dedent`
     vpc_id             = module.vpc.vpc_id
     s3_bucket_name     = module.s3_flow_log.aws_s3_bucket_name
     log_retention_days = var.vpc_flow_log_retention_days
+    query_year_ranges  = local.vpc_flow_log_query_year_ranges
   }`;
 
 const applyAwsVpcFlowLog = async (options: AwsOptions) => {
@@ -123,7 +125,7 @@ const applyAwsVpcFlowLog = async (options: AwsOptions) => {
   );
   appendToFile(
     INFRA_CORE_LOCALS_PATH,
-    vpcFlowLogLocalesContent,
+    vpcFlowLogLocalsContent,
     options.projectName
   );
   appendToFile(

--- a/src/generators/addons/aws/modules/vpcFlowLog.ts
+++ b/src/generators/addons/aws/modules/vpcFlowLog.ts
@@ -1,0 +1,142 @@
+import { dedent } from 'ts-dedent';
+
+import { AwsOptions } from '@/generators/addons/aws';
+import {
+  isAwsModuleAdded,
+  requireAwsModules,
+} from '@/generators/addons/aws/dependencies';
+import {
+  INFRA_CORE_LOCALS_PATH,
+  INFRA_CORE_MAIN_PATH,
+  INFRA_CORE_VARIABLES_PATH,
+} from '@/generators/terraform/constants';
+import { appendToFile, copy } from '@/helpers/file';
+
+import { AWS_TEMPLATE_PATH } from '../constants';
+
+const vpcFlowLogLocalesContent = dedent`
+  ### Begin VPC Flow Log ###
+  locals {
+    vpc_flow_log_s3_bucket_policy = {
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Sid    = "AWSLogDeliveryWrite"
+          Effect = "Allow"
+          Principal = {
+            Service = "delivery.logs.amazonaws.com"
+          }
+          Action   = "s3:PutObject"
+          Resource = "arn:aws:s3:::\${module.s3_flow_log.aws_s3_bucket_name}/*"
+          Condition = {
+            StringEquals = {
+              "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+              "s3:x-amz-acl"      = "bucket-owner-full-control"
+            }
+            ArnLike = {
+              "aws:SourceArn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:*"
+            }
+          }
+        },
+        {
+          Sid    = "AWSLogDeliveryAclCheck"
+          Effect = "Allow"
+          Principal = {
+            Service = "delivery.logs.amazonaws.com"
+          }
+          Action = [
+            "s3:GetBucketAcl",
+            "s3:ListBucket"
+          ]
+          Resource = "arn:aws:s3:::\${module.s3_flow_log.aws_s3_bucket_name}"
+          Condition = {
+            StringEquals = {
+              "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+            }
+            ArnLike = {
+              "aws:SourceArn" = "arn:aws:logs:\${data.aws_region.current.region}:\${data.aws_caller_identity.current.account_id}:*"
+            }
+          }
+        },
+        {
+          Effect    = "Deny"
+          Principal = "*"
+          Action    = "s3:*"
+          Resource = [
+            "arn:aws:s3:::\${module.s3_flow_log.aws_s3_bucket_name}",
+            "arn:aws:s3:::\${module.s3_flow_log.aws_s3_bucket_name}/*"
+          ]
+          Condition = {
+            Bool = {
+              "aws:SecureTransport" = "false"
+            }
+          }
+        }
+      ]
+    }
+  }
+  ### End VPC Flow Log ###`;
+
+const vpcFlowLogVariablesContent = dedent`
+  variable "vpc_flow_log_retention_days" {
+    description = "The number of days to retain VPC Flow Logs in S3"
+    type        = number
+    default     = 90
+  }`;
+
+const vpcFlowLogModuleContent = dedent`
+  module "s3_flow_log" {
+    source = "../modules/s3"
+
+    env_namespace    = local.env_namespace
+    bucket_name      = "\${local.env_namespace}-flow-logs-\${data.aws_caller_identity.current.account_id}"
+    force_destroy    = true
+    object_ownership = "BucketOwnerPreferred"
+  }
+
+  module "s3_flow_log_policy" {
+    source = "../modules/s3/bucket_policy"
+
+    s3_bucket_name = module.s3_flow_log.aws_s3_bucket_name
+    s3_bucket_policy = local.vpc_flow_log_s3_bucket_policy
+  }
+
+  module "vpc_flow_log" {
+    source = "../modules/vpc_flow_log"
+
+    env_namespace      = local.env_namespace
+    vpc_id             = module.vpc.vpc_id
+    s3_bucket_name     = module.s3_flow_log.aws_s3_bucket_name
+    log_retention_days = var.vpc_flow_log_retention_days
+  }`;
+
+const applyAwsVpcFlowLog = async (options: AwsOptions) => {
+  if (isAwsModuleAdded('vpcFlowLog', options.projectName)) {
+    return;
+  }
+  await requireAwsModules('vpcFlowLog', 'vpc', options);
+
+  copy(
+    `${AWS_TEMPLATE_PATH}/modules/vpc_flow_log`,
+    'modules/vpc_flow_log',
+    options.projectName
+  );
+  appendToFile(
+    INFRA_CORE_LOCALS_PATH,
+    vpcFlowLogLocalesContent,
+    options.projectName
+  );
+  appendToFile(
+    INFRA_CORE_VARIABLES_PATH,
+    vpcFlowLogVariablesContent,
+    options.projectName
+  );
+  appendToFile(
+    INFRA_CORE_MAIN_PATH,
+    vpcFlowLogModuleContent,
+    options.projectName
+  );
+};
+
+export default applyAwsVpcFlowLog;
+export { vpcFlowLogModuleContent, vpcFlowLogVariablesContent };

--- a/src/generators/terraform/index.ts
+++ b/src/generators/terraform/index.ts
@@ -21,7 +21,8 @@ const applyTerraformCore = async (generalOptions: GeneralOptions) => {
 
   const coreDatContent = dedent`
   data "aws_caller_identity" "current" {}
-  data "aws_partition" "current" {}`;
+  data "aws_partition" "current" {}
+  data "aws_region" "current" {}`;
 
   appendToFile(INFRA_CORE_LOCALS_PATH, coreLocalsContent, projectName);
   appendToFile(INFRA_SHARED_LOCALS_PATH, coreLocalsContent, projectName);

--- a/src/generators/terraform/types.ts
+++ b/src/generators/terraform/types.ts
@@ -11,6 +11,7 @@ const awsModules = [
   'rds',
   's3',
   'ssm',
+  'vpcFlowLog',
 ] as const;
 
 type AwsModuleName = (typeof awsModules)[number] | string;

--- a/templates/addons/aws/modules/vpc_flow_log/data.tf
+++ b/templates/addons/aws/modules/vpc_flow_log/data.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/templates/addons/aws/modules/vpc_flow_log/locals.tf
+++ b/templates/addons/aws/modules/vpc_flow_log/locals.tf
@@ -1,0 +1,54 @@
+locals {
+  ordered_partition_keys = [
+    { key = "aws_account_id", value = "string" },
+    { key = "aws_service", value = "string" },
+    { key = "aws_region", value = "string" },
+    { key = "year", value = "string" },
+    { key = "month", value = "string" },
+    { key = "day", value = "string" },
+    { key = "hour", value = "string" }
+  ]
+
+  //https://docs.aws.amazon.com/vpc/latest/userguide/flow-log-records.html#flow-logs-fields
+  ordered_table_columns = [
+    { key = "version", value = "int" },
+    { key = "account_id", value = "string" },
+    { key = "action", value = "string" },
+    { key = "interface_id", value = "string" },
+    { key = "srcaddr", value = "string" },
+    { key = "dstaddr", value = "string" },
+    { key = "srcport", value = "int" },
+    { key = "dstport", value = "int" },
+    { key = "protocol", value = "int" },
+    { key = "packets", value = "bigint" },
+    { key = "bytes", value = "bigint" },
+    { key = "start", value = "bigint" },
+    { key = "end", value = "bigint" },
+    { key = "log_status", value = "string" },
+    { key = "vpc_id", value = "string" },
+    { key = "subnet_id", value = "string" },
+    { key = "instance_id", value = "string" },
+    { key = "tcp_flags", value = "int" },
+    { key = "type", value = "string" },
+    { key = "pkt_srcaddr", value = "string" },
+    { key = "pkt_dstaddr", value = "string" },
+    { key = "region", value = "string" },
+    { key = "az_id", value = "string" },
+    { key = "sublocation_type", value = "string" },
+    { key = "sublocation_id", value = "string" },
+    { key = "pkt_src_aws_service", value = "string" },
+    { key = "pkt_dst_aws_service", value = "string" },
+    { key = "flow_direction", value = "string" },
+    { key = "traffic_path", value = "int" },
+    { key = "ecs_task_id", value = "string" },
+    { key = "reject_reason", value = "string" },
+  ]
+
+  log_format = join(
+    " ",
+    [
+      for col in local.ordered_table_columns :
+      "$${${replace(col.key, "_", "-")}}"
+    ]
+  )
+}

--- a/templates/addons/aws/modules/vpc_flow_log/main.tf
+++ b/templates/addons/aws/modules/vpc_flow_log/main.tf
@@ -65,7 +65,7 @@ resource "aws_glue_catalog_table" "vpc_flow_log_table" {
   table_type    = "EXTERNAL_TABLE"
 
   storage_descriptor {
-    location      = "s3://${var.s3_bucket_name}/AWSLogs/"
+    location      = "s3://${var.s3_bucket_name}/AWSLogs/${var.s3_key_prefix}/"
     input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
     output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
 
@@ -106,7 +106,7 @@ resource "aws_glue_catalog_table" "vpc_flow_log_table" {
     "projection.aws_region.type"       = "enum"
     "projection.aws_region.values"     = "${data.aws_region.current.region}"
     "projection.year.type"             = "integer"
-    "projection.year.range"            = "2025,2030" # Update the range as needed
+    "projection.year.range"            = var.query_year_ranges
     "projection.year.digits"           = "4"
     "projection.month.type"            = "integer"
     "projection.month.range"           = "01,12"

--- a/templates/addons/aws/modules/vpc_flow_log/main.tf
+++ b/templates/addons/aws/modules/vpc_flow_log/main.tf
@@ -1,0 +1,122 @@
+# VPC Flow Log
+resource "aws_flow_log" "vpc_flow_log" {
+  log_destination      = "arn:aws:s3:::${var.s3_bucket_name}"
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = var.vpc_id
+  log_format           = local.log_format
+  // Does NOT need IAM role here since s3 bucket policy handles the permissions
+
+  //Use Parquet format for better compression and cost efficiency when query with Athena
+  destination_options {
+    file_format                = "parquet"
+    hive_compatible_partitions = true
+    per_hour_partition         = true
+  }
+}
+
+// Lifecycle policy to expire objects in the S3 bucket
+resource "aws_s3_bucket_lifecycle_configuration" "flow_log_lifecycle" {
+  bucket = var.s3_bucket_name
+
+  rule {
+    id     = "ExpireFlowLogs"
+    status = "Enabled"
+
+    filter {
+      prefix = "" # Apply to all objects
+    }
+
+    expiration {
+      days = var.log_retention_days
+    }
+  }
+}
+
+// Athena table for VPC Flow Logs
+// Athena charges based on the amount of data scanned per query (not for table creation).
+// Using the Parquet format helps minimize scanned data, which reduces query costs.
+// https://www.amazonaws.cn/en/athena/pricing/
+resource "aws_athena_workgroup" "vpc_flow_log_athena_workgroup" {
+  name = "${var.env_namespace}-vpc-flow-logs"
+
+  configuration {
+    enforce_workgroup_configuration    = true
+    publish_cloudwatch_metrics_enabled = true
+
+    result_configuration {
+      output_location = "s3://${var.s3_bucket_name}/athena-results/"
+      encryption_configuration {
+        encryption_option = "SSE_S3"
+      }
+    }
+  }
+}
+
+resource "aws_glue_catalog_database" "vpc_flow_log_database" {
+  name        = "${var.env_namespace}-athena-vpc-flow-log-db"
+  description = "Athena database for VPC ${var.vpc_id} Flow Logs in ${var.env_namespace}"
+}
+
+resource "aws_glue_catalog_table" "vpc_flow_log_table" {
+  name          = "${var.env_namespace}-athena-vpc-flow-log-table"
+  database_name = aws_glue_catalog_database.vpc_flow_log_database.name
+  description   = "VPC ${var.vpc_id} Flow Logs Table in ${var.env_namespace}"
+  table_type    = "EXTERNAL_TABLE"
+
+  storage_descriptor {
+    location      = "s3://${var.s3_bucket_name}/AWSLogs/"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      parameters = {
+        "serialization.format" = "1"
+      }
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+
+    dynamic "columns" {
+      for_each = local.ordered_table_columns
+      content {
+        name = columns.value.key
+        type = columns.value.value
+      }
+    }
+  }
+
+  dynamic "partition_keys" {
+    for_each = local.ordered_partition_keys
+    content {
+      name = partition_keys.value.key
+      type = partition_keys.value.value
+    }
+  }
+
+  parameters = {
+    EXTERNAL                           = "TRUE"
+    "parquet.compression"              = "SNAPPY"
+    "skip.header.line.count"           = "1"
+    "projection.enabled"               = "true"
+    "projection.aws_account_id.type"   = "integer"
+    "projection.aws_account_id.digits" = "12"
+    "projection.aws_account_id.range"  = "000000000001,999999999999"
+    "projection.aws_service.type"      = "enum"
+    "projection.aws_service.values"    = "vpcflowlogs"
+    "projection.aws_region.type"       = "enum"
+    "projection.aws_region.values"     = "${data.aws_region.current.region}"
+    "projection.year.type"             = "integer"
+    "projection.year.range"            = "2025,2030" # Update the range as needed
+    "projection.year.digits"           = "4"
+    "projection.month.type"            = "integer"
+    "projection.month.range"           = "01,12"
+    "projection.month.digits"          = "2"
+    "projection.day.type"              = "integer"
+    "projection.day.range"             = "01,31"
+    "projection.day.digits"            = "2"
+    "projection.hour.type"             = "integer"
+    "projection.hour.range"            = "00,23"
+    "projection.hour.digits"           = "2"
+    "storage.location.template"        = "s3://${var.s3_bucket_name}/AWSLogs/aws-account-id=$${aws_account_id}/aws-service=$${aws_service}/aws-region=$${aws_region}/year=$${year}/month=$${month}/day=$${day}/hour=$${hour}/"
+  }
+}

--- a/templates/addons/aws/modules/vpc_flow_log/outputs.tf
+++ b/templates/addons/aws/modules/vpc_flow_log/outputs.tf
@@ -1,0 +1,10 @@
+output "vpc_flow_log_arn" {
+  description = "The ARN of the VPC Flow Log"
+  value       = aws_flow_log.vpc_flow_log.arn
+}
+
+output "vpc_flow_log_athena_table_arn" {
+  description = "The arn of the Athena table for VPC Flow Logs"
+  value       = aws_glue_catalog_table.vpc_flow_log_table.arn
+}
+

--- a/templates/addons/aws/modules/vpc_flow_log/variables.tf
+++ b/templates/addons/aws/modules/vpc_flow_log/variables.tf
@@ -13,8 +13,19 @@ variable "s3_bucket_name" {
   type        = string
 }
 
+variable "s3_key_prefix" {
+  description = "The prefix for the S3 key to store the flow logs."
+  type        = string
+  default     = ""
+}
+
 variable "log_retention_days" {
   description = "The number of days to retain the flow logs in S3."
   type        = number
-  default     = 90
+  default     = 30
+}
+
+variable "query_year_ranges" {
+  description = "The range of years to query in Athena. Format: 'start_year,end_year'. Update the range as needed."
+  type        = string
 }

--- a/templates/addons/aws/modules/vpc_flow_log/variables.tf
+++ b/templates/addons/aws/modules/vpc_flow_log/variables.tf
@@ -1,0 +1,20 @@
+variable "env_namespace" {
+  description = "The namespace with environment for the VPC Flow Logs."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC to create the endpoint in."
+  type        = string
+}
+
+variable "s3_bucket_name" {
+  description = "The name of the S3 bucket to store the flow logs."
+  type        = string
+}
+
+variable "log_retention_days" {
+  description = "The number of days to retain the flow logs in S3."
+  type        = number
+  default     = 90
+}

--- a/templates/terraform/.tool-versions
+++ b/templates/terraform/.tool-versions
@@ -1,2 +1,2 @@
-terraform 1.13.3
-trivy 0.47.0
+terraform 1.14.6
+trivy 0.69.2

--- a/templates/terraform/core/main.tf
+++ b/templates/terraform/core/main.tf
@@ -1,4 +1,4 @@
 terraform {
   # Terraform version
-  required_version = "1.13.3"
+  required_version = "1.14.6"
 }

--- a/templates/terraform/shared/main.tf
+++ b/templates/terraform/shared/main.tf
@@ -1,4 +1,4 @@
 terraform {
   # Terraform version
-  required_version = "1.13.3"
+  required_version = "1.14.6"
 }


### PR DESCRIPTION
- Close #316 

## What happened 👀

- Add `vpc-flow-log` module 
- Upgrade Terraform to the latest version.
- Add `enabledSecurityFeatures` flag to make `vpc-flow-log` module an optional module. 
- Add some unit tests.

## Insight 📝

- The Terraform apply will fail since this PR has not been merged yet: https://github.com/nimblehq/infrastructure-templates/pull/309

Add a Glue table for Athena to query flow logs. Since Athena charges based on queries: https://www.amazonaws.cn/en/athena/pricing/

## Proof Of Work 📹

### Apply on AWS correctly
**Logs**

<img width="2546" height="1083" alt="Screenshot 2025-10-05 at 14 06 56" src="https://github.com/user-attachments/assets/72bafd78-524b-408d-be21-79adb8c1b227" />

**S3 bucket**

<img width="2546" height="1083" alt="Screenshot 2025-10-05 at 14 06 56" src="https://github.com/user-attachments/assets/30bde40f-dd8d-4fde-b7a4-b9cd011263a7" />

**Athena Query**

<img width="2537" height="1078" alt="Screenshot 2025-10-05 at 14 19 37" src="https://github.com/user-attachments/assets/e84ccf14-e981-4980-bb4a-f784b0824d07" />

Example query: 
[99825aeb-13ee-4801-87c3-5c512f619a50.csv](https://github.com/user-attachments/files/22706565/99825aeb-13ee-4801-87c3-5c512f619a50.csv)


### Create VPC flow log in the _Advanced_ template with flag set true.

https://github.com/user-attachments/assets/46533da4-a614-478a-8f72-25b3e5178740

### Does not create VPC flow log in _Blank_ template.

https://github.com/user-attachments/assets/9d066a19-0443-48ae-b636-24a016acb877

### Does not create VPC flow log in the Advanced template with the flag not set.

https://github.com/user-attachments/assets/7a6d27f0-f8cf-4e1b-976b-74c5dc624aa1

