### PR TITLE
Update AWS provider and modules to latest version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 18.12.1
-terraform 1.8.3
+terraform 1.13.3
 trivy 0.47.0

--- a/src/generators/addons/aws/modules/core/iamUserAndGroup.ts
+++ b/src/generators/addons/aws/modules/core/iamUserAndGroup.ts
@@ -78,11 +78,13 @@ const iamOutputsContent = dedent`
   output "iam_admin_temporary_passwords" {
     description = "List of first time passwords for admin accounts. Must be changed at first time login and will no longer be valid."
     value       = module.iam_admin_users.temporary_passwords
+    sensitive   = true
   }
 
   output "iam_developer_temporary_passwords" {
     description = "List of first time passwords for developer accounts. Must be changed at first time login and will no longer be valid."
     value       = module.iam_developer_users.temporary_passwords
+    sensitive   = true
   }`;
 
 const applyAwsIamUserAndGroup = async ({ projectName }: AwsOptions) => {

--- a/templates/addons/aws/modules/rds/main.tf
+++ b/templates/addons/aws/modules/rds/main.tf
@@ -1,6 +1,6 @@
 module "db" {
   source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "6.2.0"
+  version = "9.16.0"
 
   name = "${var.env_namespace}-aurora-db"
 
@@ -21,7 +21,6 @@ module "db" {
   autoscaling_max_capacity = var.autoscaling_max_capacity
 
   create_monitoring_role = false
-  create_random_password = false
   create_security_group  = false
   storage_encrypted      = true
 

--- a/templates/addons/aws/modules/vpc/main.tf
+++ b/templates/addons/aws/modules/vpc/main.tf
@@ -3,7 +3,7 @@ data "aws_availability_zones" "available" {}
 # trivy:ignore:AVD-AWS-0178 trivy:ignore:AVD-AWS-0164
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.0.0"
+  version = "6.4.0"
 
   name                   = "${var.env_namespace}-vpc"
   cidr                   = "10.0.0.0/16"

--- a/templates/addons/aws/providers.tf
+++ b/templates/addons/aws/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/templates/terraform/.tool-versions
+++ b/templates/terraform/.tool-versions
@@ -1,2 +1,2 @@
-terraform 1.8.3
+terraform 1.13.3
 trivy 0.47.0

--- a/templates/terraform/core/main.tf
+++ b/templates/terraform/core/main.tf
@@ -1,4 +1,4 @@
 terraform {
   # Terraform version
-  required_version = "1.8.3"
+  required_version = "1.13.3"
 }

--- a/templates/terraform/shared/main.tf
+++ b/templates/terraform/shared/main.tf
@@ -1,4 +1,4 @@
 terraform {
   # Terraform version
-  required_version = "1.8.3"
+  required_version = "1.13.3"
 }


### PR DESCRIPTION
- Close #319

## What happened 👀

- Update terraform version to 1.13.3
- Update AWS to 6.x
- Update terraform-aws-modules/rds-aurora/aws to 9.16.0
- Update terraform-aws-modules/vpc/aws to 6.4.0

## Insight 📝

- Our versions are too outdated
- Need to add sensitive=true to sensitive outputs as it's required now.

## Proof Of Work 📹

Terraform plan successful
|Shared|Core|
|----|-----|
|<img width="1009" height="821" alt="image" src="https://github.com/user-attachments/assets/78d5b240-cc47-4ff7-9190-6627c8e12e92" />|<img width="1006" height="822" alt="image" src="https://github.com/user-attachments/assets/74b6f892-7fc6-4ed9-9c4c-ddb7214d1a43" />|
