### PR TITLE
[#324] Upgrade Aurora PostgreSQL Engine Version and terraform-aws-modules/rds-aurora/aws module version

### DIFF
--- a/templates/addons/aws/modules/rds/locals.tf
+++ b/templates/addons/aws/modules/rds/locals.tf
@@ -1,0 +1,9 @@
+locals {
+  name                       = "${var.env_namespace}-aurora-db"
+  subnet_name                = "${local.name}-subnet-group"
+  engine_version             = 17.7
+  master_instance_identifier = "${var.env_namespace}-aurora-instance-master"
+  db_port                    = 5432
+  logs_exports               = ["postgresql"]
+  deletion_protection        = true
+}

--- a/templates/addons/aws/modules/rds/main.tf
+++ b/templates/addons/aws/modules/rds/main.tf
@@ -1,19 +1,26 @@
 module "db" {
   source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "9.16.0"
+  version = "10.2.0"
 
-  name = "${var.env_namespace}-aurora-db"
+  name = local.name
 
   engine         = "aurora-postgresql"
-  engine_version = 15.3
+  engine_version = local.engine_version
 
   vpc_id                 = var.vpc_id
   subnets                = var.subnet_ids
   vpc_security_group_ids = var.vpc_security_group_ids
 
-  instance_class = var.instance_type
+  create_db_subnet_group = true
+  db_subnet_group_name   = local.subnet_name
+
+  cluster_instance_class = var.instance_type
   instances = {
-    main = {}
+    master = {
+      instance_type       = var.instance_type
+      identifier          = local.master_instance_identifier
+      publicly_accessible = var.publicly_accessible
+    }
   }
 
   autoscaling_enabled      = true
@@ -24,13 +31,14 @@ module "db" {
   create_security_group  = false
   storage_encrypted      = true
 
-  publicly_accessible = false
+  // Set false to manual provide password and save it to SSM secret parameter store 
+  manage_master_user_password = false
+  master_username             = var.username
+  master_password_wo          = var.password
+  master_password_wo_version  = var.password_version
+  database_name               = var.database_name
 
-  database_name       = var.database_name
-  master_username     = var.username
-  master_password     = var.password
-  port                = 5432
-  deletion_protection = true
-
-  enabled_cloudwatch_logs_exports = ["postgresql"]
+  port                            = local.db_port
+  deletion_protection             = local.deletion_protection
+  enabled_cloudwatch_logs_exports = local.logs_exports
 }

--- a/templates/addons/aws/modules/rds/variables.tf
+++ b/templates/addons/aws/modules/rds/variables.tf
@@ -47,3 +47,16 @@ variable "autoscaling_max_capacity" {
   description = "Maximum number of read replicas when autoscaling is enabled (0 or more, 5 recommended)"
   default     = 0
 }
+
+variable "publicly_accessible" {
+  description = "Allow RDS instances to have public IP addresses"
+  type        = bool
+  default     = false
+}
+
+variable "password_version" {
+  description = "The version of the password stored in SSM Parameter Store, Increase this value when you want to update the password."
+  type        = string
+  default     = 1
+}
+

--- a/templates/addons/aws/modules/rds/variables.tf
+++ b/templates/addons/aws/modules/rds/variables.tf
@@ -56,7 +56,7 @@ variable "publicly_accessible" {
 
 variable "password_version" {
   description = "The version of the password stored in SSM Parameter Store, Increase this value when you want to update the password."
-  type        = string
+  type        = number
   default     = 1
 }
 


### PR DESCRIPTION
- Close #324 

## What happened 👀

- Upgrade `engine_version` from **15.3** to **17.7**
- Update `terraform-aws-modules/rds-aurora/aws` from **9.16.0** to **10.2.0**
- Create two new variables.
- Create `locals.tf` to handle local properties.

## Insight 📝

- The current RDS module is using **Aurora PostgreSQL engine version [15.3](https://github.com/nimblehq/infrastructure-templates/blob/ab963e822d27748f43be7566b5de99fe33b1f16f/templates/addons/aws/modules/rds/main.tf#L8)**, which is outdated. AWS has released newer versions, and upgrading to the latest supported version ([**17.7**](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraPostgreSQLReleaseNotes/AuroraPostgreSQL.Updates.html#aurorapostgresql-versions-version177x-177)) will provide performance improvements, bug fixes, and important security updates.

<img width="2559" height="1160" alt="Image" src="https://github.com/user-attachments/assets/1b1cc5eb-b853-442a-950c-6ad8567d5db9" />

-  The **`terraform-aws-modules/rds-aurora/aws`** module is also outdated ([version 9.16.0](https://github.com/nimblehq/infrastructure-templates/blob/ab963e822d27748f43be7566b5de99fe33b1f16f/templates/addons/aws/modules/rds/main.tf#L3)) and should be upgraded to **version [10.2.0](https://registry.terraform.io/modules/terraform-aws-modules/rds-aurora/aws/latest)** to align with the latest module version.
- Create `locals.tf` file to help us more easier to maintance the RDS module and easily change properties.

## Proof Of Work 📹

**Test applying the RDS module successfully**


https://github.com/user-attachments/assets/8a669bbe-d066-405a-9314-73a3d4ec9600

